### PR TITLE
Solana: fix finalize transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,6 +4352,7 @@ dependencies = [
  "near-rpc-client",
  "near-token",
  "omni-types",
+ "serde",
  "serde_json",
  "tracing",
 ]

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -12,6 +12,7 @@ near-primitives.workspace = true
 near-token.workspace = true
 near-contract-standards.workspace = true
 omni-types.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 near-rpc-client = { path = "../../near-rpc-client" }

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
@@ -77,7 +77,7 @@ impl NearBridgeClient {
             token_id,
             "get_native_token_id".to_string(),
             serde_json::json!({
-                "origin_chain": origin_chain
+                "chain": origin_chain
             }),
         )
         .await?;

--- a/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
@@ -407,9 +407,6 @@ impl SolanaBridgeClient {
             &spl_associated_token_account::ID,
         );
 
-        let (vault, _) =
-            Pubkey::find_program_address(&[b"vault", solana_token.as_ref()], program_id);
-
         let (wormhole_bridge, wormhole_fee_collector, wormhole_sequence) =
             self.get_wormhole_accounts().await?;
         let wormhole_message = Keypair::new();

--- a/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
@@ -280,7 +280,7 @@ impl SolanaBridgeClient {
             self.get_wormhole_accounts().await?;
         let wormhole_message = Keypair::new();
 
-        let is_solana_native = match self.get_token_owner(token).await? {
+        let is_bridged_token = match self.get_token_owner(token).await? {
             COption::Some(owner) => owner == authority,
             COption::None => false,
         };
@@ -299,12 +299,12 @@ impl SolanaBridgeClient {
                 AccountMeta::new_readonly(authority, false),
                 AccountMeta::new(token, false),
                 AccountMeta::new(from_token_account, false),
-                if is_solana_native {
+                if is_bridged_token {
+                    AccountMeta::new(*program_id, false) // Vault is not present for non-native tokens
+                } else {
                     let (vault, _) =
                         Pubkey::find_program_address(&[b"vault", token.as_ref()], program_id);
                     AccountMeta::new(vault, false)
-                } else {
-                    AccountMeta::new(*program_id, false) // Vault is not present for non-native tokens
                 },
                 AccountMeta::new(sol_vault, false),
                 AccountMeta::new(keypair.pubkey(), true),

--- a/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
@@ -5,12 +5,15 @@ use omni_types::{near_events::Nep141LockerEvent, OmniAddress};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
+    program_option::COption,
+    program_pack::Pack,
     pubkey::Pubkey,
     signature::{Keypair, Signature},
     signer::Signer,
     system_program, sysvar,
     transaction::Transaction,
 };
+use spl_token::state::Mint;
 
 mod error;
 mod instructions;
@@ -39,7 +42,6 @@ pub struct TransferId {
 pub struct DepositPayload {
     pub destination_nonce: u64,
     pub transfer_id: TransferId,
-    pub token: String,
     pub amount: u128,
     pub recipient: Pubkey,
     pub fee_recipient: Option<String>,
@@ -273,11 +275,13 @@ impl SolanaBridgeClient {
             ],
             &spl_associated_token_account::ID,
         );
-        let (vault, _) = Pubkey::find_program_address(&[b"vault", token.as_ref()], program_id);
 
         let (wormhole_bridge, wormhole_fee_collector, wormhole_sequence) =
             self.get_wormhole_accounts().await?;
         let wormhole_message = Keypair::new();
+
+        let token_owner = self.get_token_owner(token).await?;
+        let is_solana_native = token_owner.is_some() && token_owner.unwrap() == authority;
 
         let instruction_data = InitTransfer {
             amount,
@@ -293,7 +297,13 @@ impl SolanaBridgeClient {
                 AccountMeta::new_readonly(authority, false),
                 AccountMeta::new(token, false),
                 AccountMeta::new(from_token_account, false),
-                AccountMeta::new(vault, false), // Optional
+                if is_solana_native {
+                    let (vault, _) =
+                        Pubkey::find_program_address(&[b"vault", token.as_ref()], program_id);
+                    AccountMeta::new(vault, false)
+                } else {
+                    AccountMeta::new(*program_id, false) // Vault is not present for non-native tokens
+                },
                 AccountMeta::new(sol_vault, false),
                 AccountMeta::new(keypair.pubkey(), true),
                 AccountMeta::new_readonly(config, false),
@@ -531,7 +541,6 @@ impl SolanaBridgeClient {
                     origin_chain: 1,
                     origin_nonce: message_payload.transfer_id.origin_nonce,
                 },
-                token: "wrap.testnet".to_string(),
                 amount: message_payload.amount.into(),
                 recipient: match message_payload.recipient {
                     OmniAddress::Sol(addr) => Pubkey::new_from_array(addr.0),
@@ -583,6 +592,17 @@ impl SolanaBridgeClient {
 
         let signature = client.send_and_confirm_transaction(&transaction).await?;
         Ok(signature)
+    }
+
+    async fn get_token_owner(&self, token: Pubkey) -> Result<COption<Pubkey>, SolanaClientError> {
+        let client = self.client()?;
+
+        let mint_account = client.get_account(&token).await?;
+
+        let mint_data = Mint::unpack(&mint_account.data)
+            .map_err(|e| SolanaClientError::InvalidAccountData(e.to_string()))?;
+
+        Ok(mint_data.mint_authority)
     }
 
     pub fn client(&self) -> Result<&RpcClient, SolanaClientError> {

--- a/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/solana-bridge-client/src/solana_bridge_client.rs
@@ -280,8 +280,10 @@ impl SolanaBridgeClient {
             self.get_wormhole_accounts().await?;
         let wormhole_message = Keypair::new();
 
-        let token_owner = self.get_token_owner(token).await?;
-        let is_solana_native = token_owner.is_some() && token_owner.unwrap() == authority;
+        let is_solana_native = match self.get_token_owner(token).await? {
+            COption::Some(owner) => owner == authority,
+            COption::None => false,
+        };
 
         let instruction_data = InitTransfer {
             amount,


### PR DESCRIPTION
Removed Near token id as it's not needed.
Determine whether token is native or bridged by looking at mint_authority