### PR TITLE
fix: wait until tx

### DIFF
--- a/bridge-sdk/connectors/eth-connector/src/eth_connector.rs
+++ b/bridge-sdk/connectors/eth-connector/src/eth_connector.rs
@@ -7,6 +7,7 @@ use near_primitives::{
     hash::CryptoHash,
     types::{AccountId, TransactionOrReceiptId},
 };
+use near_rpc_client::ChangeRequest;
 use sha3::{Digest, Keccak256};
 use std::{str::FromStr, sync::Arc};
 
@@ -111,12 +112,14 @@ impl EthConnector {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            self.eth_connector_account_id()?.to_string(),
-            "deposit".to_string(),
-            args,
-            300_000_000_000_000,
-            0,
+            ChangeRequest {
+                method_name: "deposit".to_string(),
+                receiver_id: self.eth_connector_account_id()?.to_string(),
+                args,
+                gas: 300_000_000_000_000,
+                deposit: 0,
+                signer: self.near_signer()?,
+            },
         )
         .await?;
 
@@ -145,12 +148,14 @@ impl EthConnector {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            eth_connector_account_id,
-            "withdraw".to_string(),
-            args,
-            300_000_000_000_000,
-            1,
+            ChangeRequest {
+                method_name: "withdraw".to_string(),
+                receiver_id: eth_connector_account_id,
+                args,
+                gas: 300_000_000_000_000,
+                deposit: 1,
+                signer: self.near_signer()?,
+            },
         )
         .await?;
 

--- a/bridge-sdk/connectors/fast-bridge/src/fast_bridge.rs
+++ b/bridge-sdk/connectors/fast-bridge/src/fast_bridge.rs
@@ -5,6 +5,7 @@ use derive_builder::Builder;
 use ethers::prelude::*;
 use near_crypto::SecretKey;
 use near_primitives::{hash::CryptoHash, types::AccountId};
+use near_rpc_client::ChangeRequest;
 use sha3::{Digest, Keccak256};
 use std::{str::FromStr, sync::Arc};
 
@@ -106,12 +107,14 @@ impl FastBridge {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            token_id.to_string(),
-            "ft_transfer_call".to_string(),
-            args,
-            200_000_000_000_000,
-            1,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: fast_bridge_account_id,
+                method_name: "transfer".to_string(),
+                args,
+                gas: 20_000_000_000_000,
+                deposit: 1,
+            },
         )
         .await?;
 
@@ -178,12 +181,14 @@ impl FastBridge {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            self.fast_bridge_account_id()?.to_string(),
-            "lp_unlock".to_string(),
-            args,
-            120_000_000_000_000,
-            0,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: self.fast_bridge_account_id()?.to_string(),
+                method_name: "lp_unlock".to_string(),
+                args,
+                gas: 120_000_000_000_000,
+                deposit: 0,
+            },
         )
         .await?;
 
@@ -222,12 +227,14 @@ impl FastBridge {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            self.fast_bridge_account_id()?.to_string(),
-            "withdraw".to_string(),
-            args,
-            20_000_000_000_000,
-            0,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: self.fast_bridge_account_id()?.to_string(),
+                method_name: "withdraw".to_string(),
+                args,
+                gas: 20_000_000_000_000,
+                deposit: 0,
+            },
         )
         .await?;
 

--- a/bridge-sdk/connectors/nep141-connector/src/nep141_connector.rs
+++ b/bridge-sdk/connectors/nep141-connector/src/nep141_connector.rs
@@ -7,6 +7,7 @@ use near_primitives::{
     hash::CryptoHash,
     types::{AccountId, TransactionOrReceiptId},
 };
+use near_rpc_client::ChangeRequest;
 use sha3::{Digest, Keccak256};
 use std::{str::FromStr, sync::Arc};
 
@@ -66,12 +67,14 @@ impl Nep141Connector {
 
         let tx_id = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            self.token_locker_id()?.to_string(),
-            "log_metadata".to_string(),
-            args,
-            300_000_000_000_000,
-            0,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: self.token_locker_id()?.to_string(),
+                method_name: "log_metadata".to_string(),
+                args,
+                gas: 300_000_000_000_000,
+                deposit: 0,
+            },
         )
         .await?;
 
@@ -94,12 +97,14 @@ impl Nep141Connector {
 
         let tx_id = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            near_token_id,
-            "storage_deposit".to_string(),
-            args,
-            300_000_000_000_000,
-            amount,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: near_token_id,
+                method_name: "storage_deposit".to_string(),
+                args,
+                gas: 300_000_000_000_000,
+                deposit: amount,
+            },
         )
         .await?;
 
@@ -177,12 +182,14 @@ impl Nep141Connector {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            near_token_id,
-            "ft_transfer_call".to_string(),
-            args,
-            300_000_000_000_000,
-            1,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: near_token_id,
+                method_name: "ft_transfer_call".to_string(),
+                args,
+                gas: 300_000_000_000_000,
+                deposit: 1,
+            },
         )
         .await?;
 
@@ -316,12 +323,14 @@ impl Nep141Connector {
 
         let tx_hash = near_rpc_client::change(
             near_endpoint,
-            self.near_signer()?,
-            self.token_locker_id()?.to_string(),
-            "withdraw".to_string(),
-            args,
-            300_000_000_000_000,
-            60_000_000_000_000_000_000_000,
+            ChangeRequest {
+                signer: self.near_signer()?,
+                receiver_id: self.token_locker_id()?.to_string(),
+                method_name: "withdraw".to_string(),
+                args,
+                gas: 300_000_000_000_000,
+                deposit: 60_000_000_000_000_000_000_000,
+            },
         )
         .await?;
 


### PR DESCRIPTION
`RpcBroadcastTxAsyncRequest` which is used in `change` method always immediately returns a transaction hash even if transaction won't be included in a block