### PR TITLE
Update deploy token event signature

### DIFF
--- a/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
@@ -219,7 +219,7 @@ impl EvmBridgeClient {
         let endpoint = self.endpoint()?;
 
         let event_signature = match proof_kind {
-            ProofKind::DeployToken => "DeployToken(address,string,string,string,uint8)",
+            ProofKind::DeployToken => "DeployToken(address,string,string,string,uint8,uint8)",
             ProofKind::InitTransfer => {
                 "InitTransfer(address,address,uint64,uint128,uint128,uint128,string,string)"
             }


### PR DESCRIPTION
Update deploy token event signature, following [the update](https://github.com/Near-One/omni-bridge/commit/d54dbc49e84e55224439851d5b429f5a128cceef) in omni-bridge repo.