### PR TITLE
fix: bind token with vaa to support Solana

### DIFF
--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -472,7 +472,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 omni_connector(network, config_cli)
                     .bind_token(BindTokenArgs::BindTokenWithVaaProofTx {
                         chain_kind: chain,
-                        tx_hash: TxHash::from_str(&tx_hash).expect("Invalid tx_hash"),
+                        tx_hash,
                     })
                     .await
                     .unwrap();

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -80,7 +80,7 @@ pub enum BindTokenArgs {
     },
     BindTokenWithVaaProofTx {
         chain_kind: ChainKind,
-        tx_hash: TxHash,
+        tx_hash: String,
     },
 }
 
@@ -716,7 +716,7 @@ impl OmniConnector {
             } => {
                 let vaa = self
                     .wormhole_bridge_client()?
-                    .get_vaa_by_tx_hash(format!("{:?}", tx_hash))
+                    .get_vaa_by_tx_hash(tx_hash)
                     .await?;
                 let args = omni_types::prover_args::WormholeVerifyProofArgs {
                     proof_kind: omni_types::prover_result::ProofKind::DeployToken,


### PR DESCRIPTION
Using TxHash prevents us from using this command for Solana