### PR TITLE
Build vendored openssl for CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,6 +4721,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,6 +4737,7 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6470,6 +6480,7 @@ dependencies = [
  "borsh 1.5.5",
  "derive_builder",
  "mpl-token-metadata",
+ "openssl-sys",
  "sha2 0.10.8",
  "solana-client",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ solana-client = "2.0.13"
 spl-token = "7.0.0"
 spl-associated-token-account = "6.0.0"
 mpl-token-metadata = "5.1.0"
+openssl-sys = { version = "*", features = ["vendored"] }
 
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/solana-labs/curve25519-dalek.git"

--- a/bridge-sdk/bridge-clients/solana-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/solana-bridge-client/Cargo.toml
@@ -13,6 +13,7 @@ mpl-token-metadata.workspace = true
 spl-token.workspace = true
 spl-associated-token-account.workspace = true
 thiserror.workspace = true
+openssl-sys.workspace = true
 
 [lib]
 path = "src/solana_bridge_client.rs"


### PR DESCRIPTION
openssl-sys v0.9.106 removed openssl from dependencies which broke our CI pipelines. This commit fixes it