### PR TITLE
BTC Connector: add the required transfer amount calculation taking the fee into account.

### DIFF
--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -716,12 +716,18 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             fee,
             config_cli,
         } => {
-            let btc_address = omni_connector(network, config_cli)
+            let omni_connector = omni_connector(network, config_cli);
+            let btc_address = omni_connector
                 .get_btc_address(&recipient_id, amount, fee)
                 .await
                 .unwrap();
 
+            let transfer_amount = omni_connector
+                .get_amount_to_transfer(amount)
+                .await
+                .unwrap();
             tracing::info!("BTC Address: {btc_address}");
+            tracing::info!("Amount you need to transfer, including the fee: {transfer_amount}")
         }
     }
 }

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -727,7 +727,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .await
                 .unwrap();
             tracing::info!("BTC Address: {btc_address}");
-            tracing::info!("Amount you need to transfer, including the fee: {transfer_amount}")
+            tracing::info!("Amount you need to transfer, including the fee: {transfer_amount}");
         }
     }
 }

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -386,6 +386,13 @@ impl OmniConnector {
             .await
     }
 
+    pub async fn get_amount_to_transfer(&self, amount: u128) -> Result<u128> {
+        let near_bridge_client = self.near_bridge_client()?;
+        near_bridge_client
+            .get_amount_to_transfer(amount)
+            .await
+    }
+
     pub async fn near_fin_transfer_with_vaa(
         &self,
         chain_kind: ChainKind,


### PR DESCRIPTION
When transferring amount, some portion will be spent on the fee. The function allows you to determine how much needs to be transferred so that the recipient eventually receives the desired amount. This is especially important for transfers using ft_transfer_call, where, if the amount is not enough to cover the fee, the transfer will get stuck.