### PR TITLE
fix: verify proof block number before submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,11 +880,12 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "btc-bridge-client",
  "clap",
  "dotenv",
+ "eth-light-client",
  "ethers-core",
  "evm-bridge-client",
  "near-bridge-client",
@@ -2115,6 +2116,19 @@ dependencies = [
  "sha3",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "eth-light-client"
+version = "0.2.1"
+dependencies = [
+ "borsh 1.5.7",
+ "bridge-connector-common",
+ "derive_builder",
+ "near-primitives",
+ "near-rpc-client",
+ "near-token",
+ "serde_json",
 ]
 
 [[package]]
@@ -4604,6 +4618,7 @@ dependencies = [
  "btc-utils",
  "crypto-utils",
  "derive_builder",
+ "eth-light-client",
  "eth-proof",
  "ethers",
  "evm-bridge-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ members = [
     "bridge-sdk/bridge-clients/wormhole-bridge-client",
     "bridge-sdk/bridge-clients/btc-bridge-client",
     "bridge-sdk/crypto-utils",
-    "bridge-sdk/btc-utils"
+    "bridge-sdk/btc-utils",
+    "bridge-sdk/eth-light-client"
 ]
 
 [workspace.dependencies]
@@ -58,6 +59,7 @@ spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"]
 mpl-token-metadata = "5.1.0"
 crypto-shared = { git = "https://github.com/near-one/mpc", package = "crypto-shared", rev = "463172481597ee09b12020b72c61d6b01da7b167" }
 openssl-sys = { version = "*", features = ["vendored"] }
+eth-light-client =  { path = "bridge-sdk/eth-light-client" }
 
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/solana-labs/curve25519-dalek.git"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.2.16"
+version = "0.2.17"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 
@@ -17,6 +17,7 @@ tracing.workspace = true
 omni-types.workspace = true
 solana-client.workspace = true
 solana-sdk.workspace = true
+eth-light-client.workspace = true
 omni-connector = { path = "../bridge-sdk/connectors/omni-connector" }
 near-bridge-client = { path = "../bridge-sdk/bridge-clients/near-bridge-client" }
 evm-bridge-client = { path = "../bridge-sdk/bridge-clients/evm-bridge-client" }

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -1,7 +1,7 @@
 /// Mainnet
 pub const NEAR_RPC_MAINNET: &str = "https://archival-rpc.mainnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_MAINNET: &str = "omni.bridge.near";
-pub const ETH_LIGHT_CLIENT_MAINNET: &str = "client-eth2.bridge.near";
+pub const ETH_LIGHT_CLIENT_ID_MAINNET: &str = "client-eth2.bridge.near";
 
 pub const ETH_RPC_MAINNET: &str = "https://eth.llamarpc.com";
 pub const ETH_CHAIN_ID_MAINNET: u64 = 1;
@@ -31,7 +31,7 @@ pub const SATOSHI_RELAYER_MAINNET: &str = "satoshi_optwo.near";
 /// Testnet
 pub const NEAR_RPC_TESTNET: &str = "https://archival-rpc.testnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_TESTNET: &str = "omni.n-bridge.testnet";
-pub const ETH_LIGHT_CLIENT_TESTNET: &str = "client-eth2.sepolia.testnet";
+pub const ETH_LIGHT_CLIENT_ID_TESTNET: &str = "client-eth2.sepolia.testnet";
 
 pub const ETH_RPC_TESTNET: &str = "https://ethereum-sepolia-rpc.publicnode.com";
 pub const ETH_CHAIN_ID_TESTNET: u64 = 11_155_111;
@@ -61,7 +61,7 @@ pub const SATOSHI_RELAYER_TESTNET: &str = "cosmosfirst.testnet";
 /// Devnet
 pub const NEAR_RPC_DEVNET: &str = "https://archival-rpc.testnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_DEVNET: &str = "omni-locker.testnet";
-pub const ETH_LIGHT_CLIENT_DEVNET: &str = "client-eth2.sepolia.testnet";
+pub const ETH_LIGHT_CLIENT_ID_DEVNET: &str = "client-eth2.sepolia.testnet";
 
 pub const ETH_RPC_DEVNET: &str = "https://ethereum-sepolia-rpc.publicnode.com";
 pub const ETH_CHAIN_ID_DEVNET: u64 = 11_155_111;

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -1,6 +1,7 @@
 /// Mainnet
 pub const NEAR_RPC_MAINNET: &str = "https://archival-rpc.mainnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_MAINNET: &str = "omni.bridge.near";
+pub const ETH_LIGHT_CLIENT_MAINNET: &str = "client-eth2.bridge.near";
 
 pub const ETH_RPC_MAINNET: &str = "https://eth.llamarpc.com";
 pub const ETH_CHAIN_ID_MAINNET: u64 = 1;
@@ -30,6 +31,7 @@ pub const SATOSHI_RELAYER_MAINNET: &str = "satoshi_optwo.near";
 /// Testnet
 pub const NEAR_RPC_TESTNET: &str = "https://archival-rpc.testnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_TESTNET: &str = "omni.n-bridge.testnet";
+pub const ETH_LIGHT_CLIENT_TESTNET: &str = "client-eth2.sepolia.testnet";
 
 pub const ETH_RPC_TESTNET: &str = "https://ethereum-sepolia-rpc.publicnode.com";
 pub const ETH_CHAIN_ID_TESTNET: u64 = 11_155_111;
@@ -59,6 +61,7 @@ pub const SATOSHI_RELAYER_TESTNET: &str = "cosmosfirst.testnet";
 /// Devnet
 pub const NEAR_RPC_DEVNET: &str = "https://archival-rpc.testnet.near.org/";
 pub const NEAR_TOKEN_LOCKER_ID_DEVNET: &str = "omni-locker.testnet";
+pub const ETH_LIGHT_CLIENT_DEVNET: &str = "client-eth2.sepolia.testnet";
 
 pub const ETH_RPC_DEVNET: &str = "https://ethereum-sepolia-rpc.publicnode.com";
 pub const ETH_CHAIN_ID_DEVNET: u64 = 11_155_111;

--- a/bridge-cli/src/main.rs
+++ b/bridge-cli/src/main.rs
@@ -18,6 +18,8 @@ struct CliConfig {
     near_private_key: Option<String>,
     #[arg(long)]
     near_token_locker_id: Option<String>,
+    #[arg(long)]
+    eth_light_client_id: Option<String>,
 
     #[arg(long)]
     eth_rpc: Option<String>,
@@ -78,6 +80,7 @@ impl CliConfig {
             near_signer: self.near_signer.or(other.near_signer),
             near_private_key: self.near_private_key.or(other.near_private_key),
             near_token_locker_id: self.near_token_locker_id.or(other.near_token_locker_id),
+            eth_light_client_id: self.eth_light_client_id.or(other.eth_light_client_id),
 
             eth_rpc: self.eth_rpc.or(other.eth_rpc),
             eth_chain_id: self.eth_chain_id.or(other.eth_chain_id),
@@ -125,7 +128,7 @@ fn env_config() -> CliConfig {
         near_signer: env::var("NEAR_SIGNER").ok(),
         near_private_key: env::var("NEAR_PRIVATE_KEY").ok(),
         near_token_locker_id: env::var("TOKEN_LOCKER_ID").ok(),
-
+        eth_light_client_id: env::var("ETH_LIGHT_CLIENT_ID").ok(),
         eth_rpc: env::var("ETH_RPC").ok(),
         eth_chain_id: env::var("ETH_CHAIN_ID")
             .ok()
@@ -171,6 +174,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_MAINNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_MAINNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_MAINNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_MAINNET),
@@ -211,6 +215,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_TESTNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_TESTNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_TESTNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_TESTNET),
@@ -251,6 +256,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_DEVNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_DEVNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_DEVNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_DEVNET),

--- a/bridge-cli/src/main.rs
+++ b/bridge-cli/src/main.rs
@@ -174,7 +174,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_MAINNET.to_owned()),
-            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_MAINNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_MAINNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_MAINNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_MAINNET),
@@ -215,7 +215,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_TESTNET.to_owned()),
-            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_TESTNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_TESTNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_TESTNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_TESTNET),
@@ -256,7 +256,7 @@ fn default_config(network: Network) -> CliConfig {
             near_signer: None,
             near_private_key: None,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_DEVNET.to_owned()),
-            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_DEVNET.to_owned()),
+            eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_DEVNET.to_owned()),
 
             eth_rpc: Some(defaults::ETH_RPC_DEVNET.to_owned()),
             eth_chain_id: Some(defaults::ETH_CHAIN_ID_DEVNET),

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -3,6 +3,7 @@ use std::{path::Path, str::FromStr};
 use clap::Subcommand;
 
 use btc_bridge_client::BtcBridgeClient;
+use eth_light_client::EthLightClientBuilder;
 use ethers_core::types::TxHash;
 use evm_bridge_client::EvmBridgeClientBuilder;
 use near_bridge_client::{NearBridgeClientBuilder, TransactionOptions};
@@ -821,7 +822,7 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
     let combined_config = combined_config(cli_config, network);
 
     let near_bridge_client = NearBridgeClientBuilder::default()
-        .endpoint(combined_config.near_rpc)
+        .endpoint(combined_config.near_rpc.clone())
         .private_key(combined_config.near_private_key)
         .signer(combined_config.near_signer)
         .omni_bridge_id(combined_config.near_token_locker_id)
@@ -883,6 +884,12 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
 
     let btc_bridge_client = BtcBridgeClient::new(&combined_config.btc_endpoint.unwrap());
 
+    let eth_light_client = EthLightClientBuilder::default()
+        .endpoint(combined_config.near_rpc)
+        .eth_light_client_id(combined_config.eth_light_client_id)
+        .build()
+        .unwrap();
+
     OmniConnectorBuilder::default()
         .near_bridge_client(Some(near_bridge_client))
         .eth_bridge_client(Some(eth_bridge_client))
@@ -891,6 +898,7 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .solana_bridge_client(Some(solana_bridge_client))
         .wormhole_bridge_client(Some(wormhole_bridge_client))
         .btc_bridge_client(Some(btc_bridge_client))
+        .eth_light_client(Some(eth_light_client))
         .build()
         .unwrap()
 }

--- a/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
@@ -51,6 +51,23 @@ impl EvmBridgeClient {
         Self::default()
     }
 
+    // Gets the block number of a transaction
+    pub async fn get_tx_block_number(&self, tx_hash: TxHash) -> Result<u64> {
+        let endpoint = self.endpoint()?;
+        let client = Provider::<Http>::try_from(endpoint)
+            .map_err(|_| BridgeSdkError::ConfigError("Invalid EVM rpc endpoint url".to_string()))?;
+
+        let tx_block_number = client
+            .get_transaction(tx_hash)
+            .await?
+            .and_then(|r| r.block_number)
+            .ok_or_else(|| {
+                BridgeSdkError::UnknownError("Failed to get tx block number".to_string())
+            })?;
+
+        Ok(tx_block_number.as_u64())
+    }
+
     /// Gets last finalized block number on EVM chain
     pub async fn get_last_block_number(&self) -> Result<u64> {
         let endpoint = self.endpoint()?;

--- a/bridge-sdk/connectors/bridge-connector-common/src/result.rs
+++ b/bridge-sdk/connectors/bridge-connector-common/src/result.rs
@@ -41,6 +41,8 @@ pub enum BridgeSdkError {
     InsufficientBalance(String),
     #[error("Invalid argument provided: {0}")]
     InvalidArgument(String),
+    #[error("Light client not synced, current height {0}")]
+    LightClientNotSynced(u64),
     #[error("Unexpected error occured: {0}")]
     UnknownError(String),
 }

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -18,6 +18,7 @@ omni-types.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 solana-sdk.workspace = true
+eth-light-client.workspace = true
 eth-proof = { path = "../../eth-proof" }
 near-rpc-client = { path = "../../near-rpc-client" }
 crypto-utils = { path = "../../crypto-utils" }

--- a/bridge-sdk/eth-light-client/Cargo.toml
+++ b/bridge-sdk/eth-light-client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "eth-light-client"
+version = "0.2.1"
+edition = "2021"
+
+[dependencies]
+borsh.workspace = true
+derive_builder.workspace = true
+near-primitives.workspace = true
+near-token.workspace = true
+serde_json.workspace = true
+near-rpc-client = { path = "../near-rpc-client" }
+bridge-connector-common = { path = "../connectors/bridge-connector-common" }
+
+[lib]
+path = "src/eth_light_client.rs"

--- a/bridge-sdk/eth-light-client/src/eth_light_client.rs
+++ b/bridge-sdk/eth-light-client/src/eth_light_client.rs
@@ -1,0 +1,57 @@
+use borsh::BorshDeserialize;
+use bridge_connector_common::result::{BridgeSdkError, Result};
+use derive_builder::Builder;
+use near_primitives::types::AccountId;
+use near_rpc_client::ViewRequest;
+
+#[derive(BorshDeserialize)]
+struct EthLightClientResponse {
+    last_block_number: u64,
+}
+
+/// Ethereum light client NEAR
+#[derive(Builder, Default, Clone)]
+pub struct EthLightClient {
+    #[doc = r"NEAR RPC endpoint"]
+    endpoint: Option<String>,
+    #[doc = r"Eth light client account id on Near"]
+    eth_light_client_id: Option<String>,
+}
+
+impl EthLightClient {
+    pub async fn get_last_block_number(&self) -> Result<u64> {
+        let endpoint = self.endpoint()?;
+
+        let response = near_rpc_client::view(
+            endpoint,
+            ViewRequest {
+                contract_account_id: self.light_client_id()?,
+                method_name: "last_block_number".to_string(),
+                args: serde_json::Value::Null,
+            },
+        )
+        .await?;
+
+        let parsed_response: EthLightClientResponse = borsh::from_slice(&response)
+            .map_err(|err| BridgeSdkError::UnknownError(err.to_string()))?;
+        Ok(parsed_response.last_block_number)
+    }
+
+    pub fn light_client_id(&self) -> Result<AccountId> {
+        self.eth_light_client_id
+            .as_ref()
+            .ok_or(BridgeSdkError::ConfigError(
+                "Eth light client account id is not set".to_string(),
+            ))?
+            .parse::<AccountId>()
+            .map_err(|_| {
+                BridgeSdkError::ConfigError("Invalid Eth light client account id".to_string())
+            })
+    }
+
+    pub fn endpoint(&self) -> Result<&str> {
+        Ok(self.endpoint.as_ref().ok_or(BridgeSdkError::ConfigError(
+            "Near rpc endpoint is not set".to_string(),
+        ))?)
+    }
+}


### PR DESCRIPTION
This PR adds verification for the EVM proof block number to prevent users from submitting failed transactions when the light client has not yet synced.

Example of failed tx on deploying token:
https://nearblocks.io/txns/FRSNvDvLyrQH2Msp88PdbZQKN2BsQgvXzoHV7UE199ik?tab=enhanced