### PR TITLE
fix: approved amount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "btc-bridge-client",
  "clap",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "evm-bridge-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "borsh 1.5.7",
  "bridge-connector-common",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 

--- a/bridge-sdk/bridge-clients/evm-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-bridge-client"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
@@ -188,8 +188,7 @@ impl EvmBridgeClient {
 
             let amount256: ethers::types::U256 = amount.into();
             if allowance < amount256 {
-                let mut approval_call =
-                    bridge_token.approve(omni_bridge_address, amount256 - allowance);
+                let mut approval_call = bridge_token.approve(omni_bridge_address, amount256);
                 self.prepare_tx_for_sending(&mut approval_call, tx_nonce)
                     .await?;
                 approval_call


### PR DESCRIPTION
`approve(amount)` overrides current approval amount instead of adding a new amount to the existing one
