### PR TITLE
chore: improve UX of the fin transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.2.18"
+version = "0.3.0"
 dependencies = [
  "btc-bridge-client",
  "clap",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.2.18"
+version = "0.3.0"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 

--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -105,10 +105,9 @@ bridge-cli testnet evm-init-transfer \
     --message ""
 
 # 2. Wait for the transaction to be confirmed, then finalize on NEAR
-bridge-cli testnet near-fin-transfer-with-evm-proof \
+bridge-cli testnet near-fin-transfer \
     --chain eth \
     --tx-hash 0xabc...def \
-    --storage-deposit-actions usdc.near:alice.near:0.1
 ```
 
 ### Example 3: Transfer token from NEAR to Solana
@@ -180,13 +179,12 @@ bridge-cli near-sign-transfer \
     --fee <FEE_AMOUNT> \
     --native-fee <NATIVE_FEE_AMOUNT>
 
-# Finalize a transfer on NEAR (using EVM proof)
-bridge-cli near-fin-transfer-with-evm-proof \
+# Finalize a transfer on NEAR (for transfers from EVM)
+bridge-cli near-fin-transfer \
     --chain <SOURCE_CHAIN> \
     --tx-hash <TX_HASH> \
-    --storage-deposit-actions <TOKEN1:ACCOUNT1:AMOUNT1,...>
 
-# Finalize a transfer on NEAR (using VAA)
+# Finalize a transfer on NEAR (using VAA, use this method only for transfers from Solana)
 bridge-cli near-fin-transfer-with-vaa \
     --chain <SOURCE_CHAIN> \
     --storage-deposit-actions <TOKEN1:ACCOUNT1:AMOUNT1,...> \

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -1,5 +1,5 @@
 /// Mainnet
-pub const NEAR_RPC_MAINNET: &str = "https://archival-rpc.mainnet.near.org/";
+pub const NEAR_RPC_MAINNET: &str = "https://archival-rpc.mainnet.fastnear.com/";
 pub const NEAR_TOKEN_LOCKER_ID_MAINNET: &str = "omni.bridge.near";
 pub const ETH_LIGHT_CLIENT_ID_MAINNET: &str = "client-eth2.bridge.near";
 

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -29,7 +29,7 @@ pub const BTC_MAINNET: &str = "btc-client.bridge.near";
 pub const SATOSHI_RELAYER_MAINNET: &str = "satoshi_optwo.near";
 
 /// Testnet
-pub const NEAR_RPC_TESTNET: &str = "https://archival-rpc.testnet.near.org/";
+pub const NEAR_RPC_TESTNET: &str = "https://archival-rpc.testnet.fastnear.com/";
 pub const NEAR_TOKEN_LOCKER_ID_TESTNET: &str = "omni.n-bridge.testnet";
 pub const ETH_LIGHT_CLIENT_ID_TESTNET: &str = "client-eth2.sepolia.testnet";
 

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -101,8 +101,8 @@ pub enum OmniConnectorSubCommand {
         #[command(flatten)]
         config_cli: CliConfig,
     },
-    #[clap(about = "Finalize a transfer on NEAR using EVM proof")]
-    NearFinTransferWithEvmProof {
+    #[clap(about = "Finalize a transfer on NEAR")]
+    NearFinTransfer {
         #[clap(short, long, help = "Origin chain of the transfer to finalize")]
         chain: ChainKind,
         #[clap(
@@ -111,12 +111,6 @@ pub enum OmniConnectorSubCommand {
             help = "Transaction hash of the InitTransfer call on other chain"
         )]
         tx_hash: String,
-        #[clap(
-            short,
-            long,
-            help = "Storage deposit actions. Format: token_id1:account_id1:amount1,token_id2:account_id2:amount2,..."
-        )]
-        storage_deposit_actions: Vec<String>,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -506,32 +500,56 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .await
                 .unwrap();
         }
-        OmniConnectorSubCommand::NearFinTransferWithEvmProof {
+        OmniConnectorSubCommand::NearFinTransfer {
             chain,
             tx_hash,
-            storage_deposit_actions,
             config_cli,
-        } => {
-            omni_connector(network, config_cli)
-                .fin_transfer(FinTransferArgs::NearFinTransferWithEvmProof {
-                    chain_kind: chain,
-                    tx_hash: TxHash::from_str(&tx_hash).expect("Invalid tx_hash"),
-                    storage_deposit_actions: storage_deposit_actions
-                        .iter()
-                        .map(|action| {
-                            let parts: Vec<&str> = action.split(':').collect();
-                            omni_types::locker_args::StorageDepositAction {
-                                token_id: parts[0].parse().unwrap(),
-                                account_id: parts[1].parse().unwrap(),
-                                storage_deposit_amount: parts[2].parse().ok(),
-                            }
-                        })
-                        .collect(),
-                    transaction_options: TransactionOptions::default(),
-                })
-                .await
-                .unwrap();
-        }
+        } => match chain {
+            ChainKind::Eth => {
+                let connector = omni_connector(network, config_cli);
+                let storage_deposit_actions = connector
+                    .get_storage_deposit_actions_for_evm_tx(chain, tx_hash.parse().unwrap())
+                    .await
+                    .unwrap();
+
+                connector
+                    .fin_transfer(FinTransferArgs::NearFinTransferWithEvmProof {
+                        chain_kind: chain,
+                        tx_hash: TxHash::from_str(&tx_hash).expect("Invalid tx_hash"),
+                        storage_deposit_actions,
+                        transaction_options: TransactionOptions::default(),
+                    })
+                    .await
+                    .unwrap();
+            }
+            ChainKind::Arb | ChainKind::Base => {
+                let connector = omni_connector(network, config_cli);
+
+                let vaa = connector
+                    .wormhole_get_vaa_by_tx_hash(tx_hash.clone())
+                    .await
+                    .unwrap();
+
+                let storage_deposit_actions = connector
+                    .get_storage_deposit_actions_for_evm_tx(chain, tx_hash.parse().unwrap())
+                    .await
+                    .unwrap();
+
+                connector
+                    .fin_transfer(FinTransferArgs::NearFinTransferWithVaa {
+                        chain_kind: chain,
+                        storage_deposit_actions,
+                        vaa,
+                        transaction_options: TransactionOptions::default(),
+                    })
+                    .await
+                    .unwrap();
+            }
+            _ => {
+                // TODO: add support for Solana
+                panic!("Unsupported chain for NearFinTransfer: {:?}", chain);
+            }
+        },
         OmniConnectorSubCommand::NearFinTransferWithVaa {
             chain,
             storage_deposit_actions,

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -547,7 +547,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             }
             _ => {
                 // TODO: add support for Solana
-                panic!("Unsupported chain for NearFinTransfer: {:?}", chain);
+                panic!("Unsupported chain for NearFinTransfer: {chain:?}");
             }
         },
         OmniConnectorSubCommand::NearFinTransferWithVaa {


### PR DESCRIPTION
This PR simplifies the `NearFinTransfer` command, so no need to pass the VAA and storage deposit accounts for Base and Arbitrum chains.
I've left a couple of TODO to be fixed in a follow-up PR 