### PR TITLE
Fix formatting in README.md for fin-transfer.

### DIFF
--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -104,6 +104,7 @@ bridge-cli testnet evm-init-transfer \
 # 2. Wait for the transaction to be confirmed, then finalize on NEAR
 bridge-cli testnet near-fin-transfer \
     --chain eth \
+    --destination-chain near \
     --tx-hash 0xabc...def \
 ```
 


### PR DESCRIPTION
The bridge CLI documentation and readme are missing the required --destination-chain argument, which causes command failures and confusion during the NEAR finalization step.