### PR TITLE
chore: hardcode deposit for eth token deployment on near

### DIFF
--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.30"
+version = "0.3.31"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
@@ -497,7 +497,10 @@ impl NearBridgeClient {
         let endpoint = self.endpoint()?;
         let omni_bridge_id = self.omni_bridge_id()?;
 
-        let deposit = self.get_required_balance_for_deploy_token().await?;
+        // let deposit = self.get_required_balance_for_deploy_token().await?;
+        // TODO: temporary fix for deploy token deposit, remove when token deployer contract is
+        // updated for eth tokens
+        let deposit = NearToken::from_near(4).as_yoctonear();
 
         let tx_hash = near_rpc_client::change_and_wait(
             endpoint,


### PR DESCRIPTION
Token deployer for eth is still not migrated to use global contracts, therefore cli is broken right now, because `get_required_balance_for_deploy_token` returns new balance which is almost zero for other token deployers
