### PR TITLE
Support BTC request_refund and verify_refund commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.51"
+version = "0.3.52"
 dependencies = [
  "alloy",
  "clap",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "alloy",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.52"
+version = "0.3.53"
 dependencies = [
  "alloy",
  "clap",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-connector-common"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "alloy",
  "eth-proof",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "alloy",
  "bip0039",
@@ -11088,7 +11088,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxo-bridge-client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.45"
+version = "0.3.46"
 dependencies = [
  "alloy",
  "clap",
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "alloy",
  "bip0039",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.45"
+version = "0.3.46"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.52"
+version = "0.3.53"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -35,7 +35,7 @@ cargo build --release
 ./target/release/bridge-cli
 
 # Or install globally with
-cargo install --path ./bridge-cli
+cargo install --locked --path ./bridge-cli
 ```
 
 

--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -194,6 +194,69 @@ bridge-cli testnet btc-verify-withdraw \
     --btc-tx-hash 5d...a6
 ```
 
+### Example 6: Refund a never-finalized BTC deposit
+
+If you sent BTC to the bridge's deposit address but the transaction was never finalized on NEAR, you can pull the BTC back to a Bitcoin address you control.
+
+The pipeline has three on-chain steps. Steps 1 and 3 go through `bridge-cli`. Step 2 is a direct call to the BTC connector contract via `near-cli`, because it only becomes callable after a timelock and may be invoked by anyone (not just the depositor).
+
+```bash
+# 1. Submit the refund request.
+#
+# The CLI fetches the BTC tx, derives the expected deposit address from the
+# original deposit args (recipient_id + fee + msg), and matches it against the
+# tx outputs to resolve `vout` automatically. Pass --vout explicitly only if
+# auto-resolution reports "ambiguous".
+#
+# IMPORTANT: --recipient-id, --fee and --msg must be exactly the values used
+# at deposit time. The contract recomputes the deposit address from them and
+# rejects the request if it does not match the on-chain UTXO.
+#
+# Example: refund of a direct deposit to near.intents (safe_deposit.msg path).
+# `receiver_id` inside --msg is the intents account that the deposit was
+# routed to.
+bridge-cli mainnet btc-request-refund \
+    --btc-tx-hash cb9.....36b \
+    --recipient-id intents.near \
+    --refund-address bc1q.... \
+    --msg '{"receiver_id":"your_account.near"}'
+
+# 2. Wait for the refund timelock, then call execute_refund directly on the
+#    BTC connector contract via near-cli. Anyone can call it (the BTC tx
+#    is already pinned to your refund_address by step 1).
+#
+# Timelock rules:
+#   * 2 days — `refund_address` was provided in the original deposit
+#   * 14 days — `refund_address` was NOT provided in the original deposit
+#   * instant — caller has the DAO or RefundOperator role on the connector
+#
+# `utxo_storage_key` is "<btc_tx_hash>@<vout>" of the original deposit.
+# Attach a small deposit to cover storage for the BTCPendingInfo entry.
+
+near contract call-function as-transaction btc-connector.bridge.near \
+    execute_refund \
+    json-args '{"utxo_storage_key":"cb9.....36b@0"}' \
+    prepaid-gas '100.0 Tgas' \
+    attached-deposit '0.05 NEAR' \
+    sign-as your-account.near \
+    network-config mainnet sign-with-keychain send
+
+# 3. Trigger MPC signing of the refund BTC transaction.
+#
+# `execute_refund` creates a `BTCPendingInfo` and emits a
+# `GenerateBtcPendingInfo` event. Find `btc_pending_id` in the event logs of
+# the `execute_refund` tx (NEAR explorer or `near tx-status`) and pass it
+# below. Once signed, the relayer broadcasts the BTC tx to Bitcoin.
+bridge-cli mainnet near-sign-btc-transaction \
+    --chain btc \
+    --btc-pending-id <btc_pending_id from execute_refund logs>
+```
+
+> [!NOTE]
+> - The contract that owns this flow is [Near-One/btc-bridge](https://github.com/Near-One/btc-bridge) (`satoshi-bridge`). On mainnet it is `btc-connector.bridge.near`; on testnet `btc-connector.n-bridge.testnet`.
+> - `request_refund` will be rejected by the contract if the deposit was already finalized via `verify_deposit` / `safe_verify_deposit`.
+> - If the deposit's `DepositMsg.refund_address` was set, it must equal `--refund-address`. The contract enforces this match.
+
 > [!NOTE]
 > - You have to wait for around 20 minutes for transaction confirmation after calling any method on EVM chain. Otherwise, you'll get `ERR_INVALID_BLOCK_HASH` meaning that light client or wormhole is not yet synced with the block that transaction was included in
 > - Replace placeholder values (addresses, amounts, hashes) with actual values

--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -156,10 +156,20 @@ bridge-cli testnet get-bitcoin-address \
 # ATTENTION: Transactions with non-zero lock time are not supported. Make sure to set it to 0 in your wallet of choice.
 
 # 3. Finalize and mint tokens on NEAR
+#
+# Minimal invocation — the CLI looks up the original DepositMsg from the
+# bridge indexer by the tx's deposit-address output:
+bridge-cli testnet near-fin-transfer-btc \
+    --chain btc \
+    --btc-tx-hash cb9.....36b
+
+# To override the indexer lookup (or if the tx has multiple tracked deposit
+# outputs), pass --recipient-id and friends manually, or pass --vout to pick a
+# specific output:
 bridge-cli testnet near-fin-transfer-btc \
     --chain btc \
     --btc-tx-hash cb9.....36b \
-    --recipient alice.near
+    --recipient-id alice.near
 ```
 
 ### Example 5: Transfer BTC from NEAR to Bitcoin
@@ -203,19 +213,33 @@ The pipeline has three on-chain steps. Steps 1 and 3 go through `bridge-cli`. St
 ```bash
 # 1. Submit the refund request.
 #
-# The CLI fetches the BTC tx, derives the expected deposit address from the
-# original deposit args (recipient_id + fee + msg), and matches it against the
-# tx outputs to resolve `vout` automatically. Pass --vout explicitly only if
-# auto-resolution reports "ambiguous".
-#
-# IMPORTANT: --recipient-id, --fee and --msg must be exactly the values used
-# at deposit time. The contract recomputes the deposit address from them and
-# rejects the request if it does not match the on-chain UTXO.
-#
-# Example: refund of a direct deposit to near.intents (safe_deposit.msg path).
-# `receiver_id` inside --msg is the intents account that the deposit was
-# routed to.
+# The minimal invocation is just the chain and the BTC tx hash — the CLI asks
+# the bridge indexer which output of the tx is a tracked deposit address,
+# recovers the original DepositMsg, and uses its refund_address as the refund
+# destination:
 bridge-cli mainnet btc-request-refund \
+    --chain btc \
+    --btc-tx-hash cb9.....36b
+
+# Optional arguments:
+#   --vout N            — pick a specific output if the tx has more than one
+#                         tracked deposit address (the CLI will tell you which
+#                         vouts to choose from).
+#   --refund-address X  — only used when the original DepositMsg has no
+#                         refund_address. If the deposit message carries one,
+#                         that address is used as the refund destination.
+#   --recipient-id, --fee, --msg, --no-deposit-refund-address
+#                       — supply the original deposit args manually instead of
+#                         relying on the indexer lookup. These must match the
+#                         values used at deposit time; the contract recomputes
+#                         the deposit address from them and rejects mismatches.
+#   --dry-run           — print the `request_refund` call args as JSON without
+#                         submitting the NEAR transaction.
+#
+# Example with manual args (safe_deposit.msg path; `receiver_id` inside --msg
+# is the intents account the deposit was routed to):
+bridge-cli mainnet btc-request-refund \
+    --chain btc \
     --btc-tx-hash cb9.....36b \
     --recipient-id intents.near \
     --refund-address bc1q.... \
@@ -255,7 +279,7 @@ bridge-cli mainnet near-sign-btc-transaction \
 > [!NOTE]
 > - The contract that owns this flow is [Near-One/btc-bridge](https://github.com/Near-One/btc-bridge) (`satoshi-bridge`). On mainnet it is `btc-connector.bridge.near`; on testnet `btc-connector.n-bridge.testnet`.
 > - `request_refund` will be rejected by the contract if the deposit was already finalized via `verify_deposit` / `safe_verify_deposit`.
-> - If the deposit's `DepositMsg.refund_address` was set, it must equal `--refund-address`. The contract enforces this match.
+> - If the deposit's `DepositMsg.refund_address` was set, that address is the refund destination — `--refund-address` is ignored in this case. The contract enforces that the refund tx pays out to exactly that address.
 
 > [!NOTE]
 > - You have to wait for around 20 minutes for transaction confirmation after calling any method on EVM chain. Otherwise, you'll get `ERR_INVALID_BLOCK_HASH` meaning that light client or wormhole is not yet synced with the block that transaction was included in

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -43,6 +43,33 @@ impl From<UTXOChainArg> for ChainKind {
     }
 }
 
+/// CLI recipient for a BTC deposit.
+///
+/// * `<chain>:<address>` (e.g. `eth:0xabc...`, `near:alice.near`) → routed through
+///   the Omni Bridge.
+/// * Plain NEAR account (e.g. `alice.near`, no colon) → direct nBTC mint on NEAR.
+#[derive(Clone, Debug)]
+pub enum DepositRecipient {
+    OmniBridge(OmniAddress),
+    NearDirect(AccountId),
+}
+
+impl FromStr for DepositRecipient {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(':') {
+            OmniAddress::from_str(s)
+                .map(DepositRecipient::OmniBridge)
+                .map_err(|e| e.to_string())
+        } else {
+            AccountId::from_str(s)
+                .map(DepositRecipient::NearDirect)
+                .map_err(|e| e.to_string())
+        }
+    }
+}
+
 impl From<Network> for utxo_utils::address::Network {
     fn from(value: Network) -> Self {
         match value {
@@ -583,12 +610,16 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         vout: usize,
-        #[clap(short, long, help = "Original deposit recipient on NEAR (OmniAddress)")]
-        recipient_id: OmniAddress,
         #[clap(
             short,
             long,
-            help = "The Omni Bridge Fee in satoshi that was used at deposit time",
+            help = "Original deposit recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit."
+        )]
+        recipient_id: DepositRecipient,
+        #[clap(
+            short,
+            long,
+            help = "The Omni Bridge Fee in satoshi used at deposit time (ignored for direct NEAR deposits)",
             default_value = "0"
         )]
         fee: u128,
@@ -1380,15 +1411,24 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             gas_fee,
             config_cli,
         } => {
+            let btc_deposit_args = match recipient_id {
+                DepositRecipient::OmniBridge(recipient_id) => BtcDepositArgs::OmniDepositArgs {
+                    recipient_id,
+                    fee,
+                    refund_address: Some(refund_address.clone()),
+                },
+                DepositRecipient::NearDirect(recipient_id) => {
+                    BtcDepositArgs::NearDirectDepositArgs {
+                        recipient_id,
+                        refund_address: Some(refund_address.clone()),
+                    }
+                }
+            };
             omni_connector(network, config_cli)
                 .btc_request_refund(
                     btc_tx_hash,
                     vout,
-                    BtcDepositArgs::OmniDepositArgs {
-                        recipient_id,
-                        fee,
-                        refund_address: Some(refund_address.clone()),
-                    },
+                    btc_deposit_args,
                     refund_address,
                     gas_fee,
                     TransactionOptions::default(),

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -72,6 +72,78 @@ impl From<Network> for utxo_utils::address::Network {
     }
 }
 
+/// Resolve the deposit `vout` by matching tx outputs against the deposit
+/// address derived from `deposit_args` via the bridge indexer.
+///
+/// Returns an error if no output matches or if multiple outputs match
+/// (in which case the candidate vouts are listed).
+async fn resolve_deposit_vout(
+    connector: &OmniConnector,
+    chain: ChainKind,
+    network: Network,
+    tx_hash: &str,
+    deposit_args: &BtcDepositArgs,
+) -> Result<usize, String> {
+    let expected_address = match deposit_args {
+        BtcDepositArgs::OmniDepositArgs {
+            recipient_id,
+            refund_address,
+            fee,
+        } => connector
+            .get_btc_address(chain, recipient_id, refund_address.clone(), *fee)
+            .await
+            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
+        BtcDepositArgs::NearDirectDepositArgs {
+            recipient_id,
+            refund_address,
+        } => connector
+            .get_btc_address_for_near_account(
+                chain,
+                recipient_id.clone(),
+                refund_address.clone(),
+            )
+            .await
+            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
+        BtcDepositArgs::DepositMsg { msg } => connector
+            .get_btc_address_from_deposit_msg(chain, msg)
+            .await
+            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
+    };
+
+    let expected_script =
+        utxo_utils::address::UTXOAddress::parse(&expected_address, chain, network.into())
+            .map_err(|e| format!("Failed to parse deposit address `{expected_address}`: {e}"))?
+            .script_pubkey()
+            .map_err(|e| format!("Failed to derive script_pubkey for `{expected_address}`: {e}"))?;
+
+    let proof_data = connector
+        .utxo_bridge_client(chain)
+        .map_err(|e| format!("Failed to obtain UTXO bridge client: {e}"))?
+        .extract_btc_proof(tx_hash)
+        .await
+        .map_err(|e| format!("Failed to fetch tx {tx_hash}: {e}"))?;
+
+    let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
+        .map_err(|e| format!("Failed to parse tx {tx_hash}: {e}"))?;
+
+    let matches: Vec<usize> = btc_tx
+        .output
+        .iter()
+        .enumerate()
+        .filter_map(|(i, out)| (out.script_pubkey == expected_script).then_some(i))
+        .collect();
+
+    match matches.as_slice() {
+        [] => Err(format!(
+            "No output in tx {tx_hash} matches deposit address `{expected_address}`. Verify the recipient/fee/msg match the original deposit."
+        )),
+        [v] => Ok(*v),
+        many => Err(format!(
+            "Ambiguous: multiple outputs in tx {tx_hash} match deposit address `{expected_address}`. Re-run with --vout set to one of: {many:?}"
+        )),
+    }
+}
+
 fn derive_evm_sender(chain: ChainKind, config: &CliConfig) -> Result<String, String> {
     let pk = match chain {
         ChainKind::Eth => &config.eth_private_key,
@@ -535,10 +607,9 @@ pub enum OmniConnectorSubCommand {
         #[clap(
             short,
             long,
-            help = "The index of the output in the Bitcoin transaction",
-            default_value = "0"
+            help = "The index of the output in the Bitcoin transaction. If omitted, it is auto-resolved by matching outputs against the deposit address derived from the recipient/fee/msg."
         )]
-        vout: usize,
+        vout: Option<usize>,
         #[clap(
             short,
             long,
@@ -612,10 +683,9 @@ pub enum OmniConnectorSubCommand {
         #[clap(
             short,
             long,
-            help = "The index of the deposit output in the Bitcoin transaction",
-            default_value = "0"
+            help = "The index of the deposit output in the Bitcoin transaction. If omitted, it is auto-resolved by matching outputs against the deposit address derived from the recipient/fee/msg."
         )]
-        vout: usize,
+        vout: Option<usize>,
         #[clap(
             short,
             long,
@@ -1372,9 +1442,27 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 },
             };
 
+            let resolved_vout = match vout {
+                Some(v) => v,
+                None => resolve_deposit_vout(
+                    &connector,
+                    chain.into(),
+                    network,
+                    &btc_tx_hash,
+                    &deposit_args,
+                )
+                .await
+                .unwrap(),
+            };
+
             if dry_run {
                 let args = connector
-                    .build_fin_btc_transfer_args(chain.into(), btc_tx_hash, vout, deposit_args)
+                    .build_fin_btc_transfer_args(
+                        chain.into(),
+                        btc_tx_hash,
+                        resolved_vout,
+                        deposit_args,
+                    )
                     .await
                     .unwrap();
                 let method_name = if args.deposit_msg.safe_deposit.is_some() {
@@ -1389,7 +1477,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     .fin_transfer(FinTransferArgs::NearFinTransferBTC {
                         chain_kind: chain.into(),
                         btc_tx_hash,
-                        vout,
+                        vout: resolved_vout,
                         btc_deposit_args: deposit_args,
                         transaction_options: TransactionOptions::default(),
                     })
@@ -1457,6 +1545,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             gas_fee,
             config_cli,
         } => {
+            let connector = omni_connector(network, config_cli);
             let btc_deposit_args = match recipient_id {
                 BtcRecipient::Omni(recipient_id) => {
                     if msg.is_some() {
@@ -1478,10 +1567,24 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     },
                 },
             };
-            omni_connector(network, config_cli)
+
+            let resolved_vout = match vout {
+                Some(v) => v,
+                None => resolve_deposit_vout(
+                    &connector,
+                    ChainKind::Btc,
+                    network,
+                    &btc_tx_hash,
+                    &btc_deposit_args,
+                )
+                .await
+                .unwrap(),
+            };
+
+            connector
                 .btc_request_refund(
                     btc_tx_hash,
-                    vout,
+                    resolved_vout,
                     btc_deposit_args,
                     refund_address,
                     gas_fee,

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -634,6 +634,12 @@ pub enum OmniConnectorSubCommand {
             help = "Optional msg set as SafeDepositMsg.msg used at deposit time (only valid with direct recipient, i.e. without chain prefix)"
         )]
         msg: Option<String>,
+        #[clap(
+            long,
+            help = "Set this if the original deposit's DepositMsg.refund_address was None. When set, --refund-address is used only as the refund destination and is NOT included in the deposit message used to recompute the on-chain UTXO.",
+            default_value_t = false
+        )]
+        no_deposit_refund_address: bool,
         #[clap(long, help = "Optional custom gas fee in satoshi (DAO/Operator only)")]
         gas_fee: Option<u128>,
         #[command(flatten)]
@@ -1465,10 +1471,16 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             fee,
             refund_address,
             msg,
+            no_deposit_refund_address,
             gas_fee,
             config_cli,
         } => {
             let connector = omni_connector(network, config_cli);
+            let deposit_refund_address = if no_deposit_refund_address {
+                None
+            } else {
+                Some(refund_address.clone())
+            };
             let btc_deposit_args = match recipient_id {
                 BtcRecipient::Omni(recipient_id) => {
                     if msg.is_some() {
@@ -1476,7 +1488,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     }
                     BtcDepositArgs::OmniDepositArgs {
                         recipient_id,
-                        refund_address: Some(refund_address.clone()),
+                        refund_address: deposit_refund_address,
                         fee,
                     }
                 }
@@ -1486,7 +1498,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                         post_actions: None,
                         extra_msg: None,
                         safe_deposit: msg.map(|msg| SafeDepositMsg { msg }),
-                        refund_address: Some(refund_address.clone()),
+                        refund_address: deposit_refund_address,
                     },
                 },
             };

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -567,6 +567,40 @@ pub enum OmniConnectorSubCommand {
         #[command(flatten)]
         config_cli: CliConfig,
     },
+    #[clap(about = "Request a refund for a never-finalized BTC deposit (Bitcoin only)")]
+    BtcRequestRefund {
+        #[clap(short, long, help = "Bitcoin deposit tx hash")]
+        btc_tx_hash: String,
+        #[clap(
+            short,
+            long,
+            help = "The index of the deposit output in the Bitcoin transaction",
+            default_value = "0"
+        )]
+        vout: usize,
+        #[clap(short, long, help = "Original deposit recipient on NEAR (OmniAddress)")]
+        recipient_id: OmniAddress,
+        #[clap(
+            short,
+            long,
+            help = "The Omni Bridge Fee in satoshi that was used at deposit time",
+            default_value = "0"
+        )]
+        fee: u128,
+        #[clap(long, help = "BTC address to send the refund to")]
+        refund_address: String,
+        #[clap(long, help = "Optional custom gas fee in satoshi (DAO/Operator only)")]
+        gas_fee: Option<u128>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
+    #[clap(about = "Verify the refund BTC transaction is confirmed (Bitcoin only)")]
+    BtcVerifyRefundFinalize {
+        #[clap(short, long, help = "Refund Bitcoin tx hash")]
+        btc_tx_hash: String,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
     #[clap(about = "Finalize Transfer from Near on Bitcoin")]
     BtcFinTransfer {
         #[clap(short, long, help = "Chain for the UTXO rebalancing (Bitcoin/Zcash)")]
@@ -1319,6 +1353,36 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     btc_tx_hash,
                     TransactionOptions::default(),
                 )
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::BtcRequestRefund {
+            btc_tx_hash,
+            vout,
+            recipient_id,
+            fee,
+            refund_address,
+            gas_fee,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .btc_request_refund(
+                    btc_tx_hash,
+                    vout,
+                    BtcDepositArgs::OmniDepositArgs { recipient_id, fee },
+                    refund_address,
+                    gas_fee,
+                    TransactionOptions::default(),
+                )
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::BtcVerifyRefundFinalize {
+            btc_tx_hash,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .btc_verify_refund_finalize(btc_tx_hash, TransactionOptions::default())
                 .await
                 .unwrap();
         }

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -72,78 +72,6 @@ impl From<Network> for utxo_utils::address::Network {
     }
 }
 
-/// Resolve the deposit `vout` by matching tx outputs against the deposit
-/// address derived from `deposit_args` via the bridge indexer.
-///
-/// Returns an error if no output matches or if multiple outputs match
-/// (in which case the candidate vouts are listed).
-async fn resolve_deposit_vout(
-    connector: &OmniConnector,
-    chain: ChainKind,
-    network: Network,
-    tx_hash: &str,
-    deposit_args: &BtcDepositArgs,
-) -> Result<usize, String> {
-    let expected_address = match deposit_args {
-        BtcDepositArgs::OmniDepositArgs {
-            recipient_id,
-            refund_address,
-            fee,
-        } => connector
-            .get_btc_address(chain, recipient_id, refund_address.clone(), *fee)
-            .await
-            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
-        BtcDepositArgs::NearDirectDepositArgs {
-            recipient_id,
-            refund_address,
-        } => connector
-            .get_btc_address_for_near_account(
-                chain,
-                recipient_id.clone(),
-                refund_address.clone(),
-            )
-            .await
-            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
-        BtcDepositArgs::DepositMsg { msg } => connector
-            .get_btc_address_from_deposit_msg(chain, msg)
-            .await
-            .map_err(|e| format!("Failed to fetch deposit address: {e}"))?,
-    };
-
-    let expected_script =
-        utxo_utils::address::UTXOAddress::parse(&expected_address, chain, network.into())
-            .map_err(|e| format!("Failed to parse deposit address `{expected_address}`: {e}"))?
-            .script_pubkey()
-            .map_err(|e| format!("Failed to derive script_pubkey for `{expected_address}`: {e}"))?;
-
-    let proof_data = connector
-        .utxo_bridge_client(chain)
-        .map_err(|e| format!("Failed to obtain UTXO bridge client: {e}"))?
-        .extract_btc_proof(tx_hash)
-        .await
-        .map_err(|e| format!("Failed to fetch tx {tx_hash}: {e}"))?;
-
-    let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
-        .map_err(|e| format!("Failed to parse tx {tx_hash}: {e}"))?;
-
-    let matches: Vec<usize> = btc_tx
-        .output
-        .iter()
-        .enumerate()
-        .filter_map(|(i, out)| (out.script_pubkey == expected_script).then_some(i))
-        .collect();
-
-    match matches.as_slice() {
-        [] => Err(format!(
-            "No output in tx {tx_hash} matches deposit address `{expected_address}`. Verify the recipient/fee/msg match the original deposit."
-        )),
-        [v] => Ok(*v),
-        many => Err(format!(
-            "Ambiguous: multiple outputs in tx {tx_hash} match deposit address `{expected_address}`. Re-run with --vout set to one of: {many:?}"
-        )),
-    }
-}
-
 fn derive_evm_sender(chain: ChainKind, config: &CliConfig) -> Result<String, String> {
     let pk = match chain {
         ChainKind::Eth => &config.eth_private_key,
@@ -1444,15 +1372,10 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
 
             let resolved_vout = match vout {
                 Some(v) => v,
-                None => resolve_deposit_vout(
-                    &connector,
-                    chain.into(),
-                    network,
-                    &btc_tx_hash,
-                    &deposit_args,
-                )
-                .await
-                .unwrap(),
+                None => connector
+                    .resolve_deposit_vout(chain.into(), network.into(), &btc_tx_hash, &deposit_args)
+                    .await
+                    .unwrap(),
             };
 
             if dry_run {
@@ -1570,15 +1493,15 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
 
             let resolved_vout = match vout {
                 Some(v) => v,
-                None => resolve_deposit_vout(
-                    &connector,
-                    ChainKind::Btc,
-                    network,
-                    &btc_tx_hash,
-                    &btc_deposit_args,
-                )
-                .await
-                .unwrap(),
+                None => connector
+                    .resolve_deposit_vout(
+                        ChainKind::Btc,
+                        network.into(),
+                        &btc_tx_hash,
+                        &btc_deposit_args,
+                    )
+                    .await
+                    .unwrap(),
             };
 
             connector

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -631,6 +631,11 @@ pub enum OmniConnectorSubCommand {
         fee: u128,
         #[clap(long, help = "BTC address to send the refund to")]
         refund_address: String,
+        #[clap(
+            long,
+            help = "Optional msg set as SafeDepositMsg.msg used at deposit time (only valid with direct recipient, i.e. without chain prefix)"
+        )]
+        msg: Option<String>,
         #[clap(long, help = "Optional custom gas fee in satoshi (DAO/Operator only)")]
         gas_fee: Option<u128>,
         #[command(flatten)]
@@ -1448,18 +1453,29 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             recipient_id,
             fee,
             refund_address,
+            msg,
             gas_fee,
             config_cli,
         } => {
             let btc_deposit_args = match recipient_id {
-                BtcRecipient::Omni(recipient_id) => BtcDepositArgs::OmniDepositArgs {
-                    recipient_id,
-                    fee,
-                    refund_address: Some(refund_address.clone()),
-                },
-                BtcRecipient::Direct(recipient_id) => BtcDepositArgs::NearDirectDepositArgs {
-                    recipient_id,
-                    refund_address: Some(refund_address.clone()),
+                BtcRecipient::Omni(recipient_id) => {
+                    if msg.is_some() {
+                        panic!("--msg is not supported with chain-prefixed recipient; use a direct NEAR account (e.g. 'foo.near') instead");
+                    }
+                    BtcDepositArgs::OmniDepositArgs {
+                        recipient_id,
+                        refund_address: Some(refund_address.clone()),
+                        fee,
+                    }
+                }
+                BtcRecipient::Direct(account_id) => BtcDepositArgs::DepositMsg {
+                    msg: DepositMsg {
+                        recipient_id: account_id,
+                        post_actions: None,
+                        extra_msg: None,
+                        safe_deposit: msg.map(|msg| SafeDepositMsg { msg }),
+                        refund_address: Some(refund_address.clone()),
+                    },
                 },
             };
             omni_connector(network, config_cli)

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -546,14 +546,18 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         vout: usize,
-        #[clap(short, long, help = "The BTC recipient on NEAR")]
-        recipient_id: OmniAddress,
+        #[clap(
+            short,
+            long,
+            help = "The BTC recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit."
+        )]
+        recipient_id: DepositRecipient,
         #[clap(short, long, help = "Refund recipient address (Bitcoin/Zcash)")]
         refund_address: Option<String>,
         #[clap(
             short,
             long,
-            help = "The Omni Bridge Fee in satoshi",
+            help = "The Omni Bridge Fee in satoshi (ignored for direct NEAR deposits)",
             default_value = "0"
         )]
         fee: u128,
@@ -1335,16 +1339,25 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             fee,
             config_cli,
         } => {
+            let btc_deposit_args = match recipient_id {
+                DepositRecipient::OmniBridge(recipient_id) => BtcDepositArgs::OmniDepositArgs {
+                    recipient_id,
+                    refund_address,
+                    fee,
+                },
+                DepositRecipient::NearDirect(recipient_id) => {
+                    BtcDepositArgs::NearDirectDepositArgs {
+                        recipient_id,
+                        refund_address,
+                    }
+                }
+            };
             omni_connector(network, config_cli)
                 .fin_transfer(FinTransferArgs::NearFinTransferBTC {
                     chain_kind: chain.into(),
                     btc_tx_hash,
                     vout,
-                    btc_deposit_args: BtcDepositArgs::OmniDepositArgs {
-                        recipient_id,
-                        refund_address,
-                        fee,
-                    },
+                    btc_deposit_args,
                     transaction_options: TransactionOptions::default(),
                 })
                 .await

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -1376,12 +1376,20 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 },
             };
 
-            let resolved_vout = match vout {
-                Some(v) => v,
-                None => connector
-                    .resolve_deposit_vout(chain.into(), network.into(), &btc_tx_hash, &deposit_args)
-                    .await
-                    .unwrap(),
+            let (resolved_vout, prefetched) = match vout {
+                Some(v) => (v, None),
+                None => {
+                    let (v, p) = connector
+                        .resolve_deposit_vout(
+                            chain.into(),
+                            network.into(),
+                            &btc_tx_hash,
+                            &deposit_args,
+                        )
+                        .await
+                        .unwrap();
+                    (v, Some(p))
+                }
             };
 
             if dry_run {
@@ -1391,6 +1399,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                         btc_tx_hash,
                         resolved_vout,
                         deposit_args,
+                        prefetched,
                     )
                     .await
                     .unwrap();
@@ -1408,6 +1417,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                         btc_tx_hash,
                         vout: resolved_vout,
                         btc_deposit_args: deposit_args,
+                        prefetched,
                         transaction_options: TransactionOptions::default(),
                     })
                     .await
@@ -1503,17 +1513,20 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 },
             };
 
-            let resolved_vout = match vout {
-                Some(v) => v,
-                None => connector
-                    .resolve_deposit_vout(
-                        ChainKind::Btc,
-                        network.into(),
-                        &btc_tx_hash,
-                        &btc_deposit_args,
-                    )
-                    .await
-                    .unwrap(),
+            let (resolved_vout, prefetched) = match vout {
+                Some(v) => (v, None),
+                None => {
+                    let (v, p) = connector
+                        .resolve_deposit_vout(
+                            ChainKind::Btc,
+                            network.into(),
+                            &btc_tx_hash,
+                            &btc_deposit_args,
+                        )
+                        .await
+                        .unwrap();
+                    (v, Some(p))
+                }
             };
 
             connector
@@ -1523,6 +1536,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     btc_deposit_args,
                     refund_address,
                     gas_fee,
+                    prefetched,
                     TransactionOptions::default(),
                 )
                 .await

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -43,20 +43,6 @@ impl From<UTXOChainArg> for ChainKind {
     }
 }
 
-<<<<<<< HEAD
-/// CLI recipient for a BTC deposit.
-///
-/// * `<chain>:<address>` (e.g. `eth:0xabc...`, `near:alice.near`) → routed through
-///   the Omni Bridge.
-/// * Plain NEAR account (e.g. `alice.near`, no colon) → direct nBTC mint on NEAR.
-#[derive(Clone, Debug)]
-pub enum DepositRecipient {
-    OmniBridge(OmniAddress),
-    NearDirect(AccountId),
-}
-
-impl FromStr for DepositRecipient {
-=======
 #[derive(Clone, Debug)]
 pub enum BtcRecipient {
     Direct(AccountId),
@@ -64,24 +50,14 @@ pub enum BtcRecipient {
 }
 
 impl FromStr for BtcRecipient {
->>>>>>> main
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.contains(':') {
-<<<<<<< HEAD
-            OmniAddress::from_str(s)
-                .map(DepositRecipient::OmniBridge)
-                .map_err(|e| e.to_string())
-        } else {
-            AccountId::from_str(s)
-                .map(DepositRecipient::NearDirect)
-=======
             OmniAddress::from_str(s).map(Self::Omni)
         } else {
             AccountId::from_str(s)
                 .map(Self::Direct)
->>>>>>> main
                 .map_err(|e| e.to_string())
         }
     }
@@ -566,26 +542,15 @@ pub enum OmniConnectorSubCommand {
         #[clap(
             short,
             long,
-<<<<<<< HEAD
-            help = "The BTC recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit."
-        )]
-        recipient_id: DepositRecipient,
-        #[clap(short, long, help = "Refund recipient address (Bitcoin/Zcash)")]
-=======
             help = "The BTC recipient. With chain prefix (e.g. 'near:foo.near') routes via the Omni Bridge; without prefix (e.g. 'foo.near') makes a direct deposit to that NEAR account"
         )]
         recipient_id: BtcRecipient,
         #[clap(long, help = "Refund recipient address (Bitcoin/Zcash)")]
->>>>>>> main
         refund_address: Option<String>,
         #[clap(
             short,
             long,
-<<<<<<< HEAD
-            help = "The Omni Bridge Fee in satoshi (ignored for direct NEAR deposits)",
-=======
             help = "The Omni Bridge Fee in satoshi (used only with chain-prefixed recipient)",
->>>>>>> main
             default_value = "0"
         )]
         fee: u128,
@@ -656,7 +621,7 @@ pub enum OmniConnectorSubCommand {
             long,
             help = "Original deposit recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit."
         )]
-        recipient_id: DepositRecipient,
+        recipient_id: BtcRecipient,
         #[clap(
             short,
             long,
@@ -1379,31 +1344,6 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             dry_run,
             config_cli,
         } => {
-<<<<<<< HEAD
-            let btc_deposit_args = match recipient_id {
-                DepositRecipient::OmniBridge(recipient_id) => BtcDepositArgs::OmniDepositArgs {
-                    recipient_id,
-                    refund_address,
-                    fee,
-                },
-                DepositRecipient::NearDirect(recipient_id) => {
-                    BtcDepositArgs::NearDirectDepositArgs {
-                        recipient_id,
-                        refund_address,
-                    }
-                }
-            };
-            omni_connector(network, config_cli)
-                .fin_transfer(FinTransferArgs::NearFinTransferBTC {
-                    chain_kind: chain.into(),
-                    btc_tx_hash,
-                    vout,
-                    btc_deposit_args,
-                    transaction_options: TransactionOptions::default(),
-                })
-                .await
-                .unwrap();
-=======
             let connector = omni_connector(network, config_cli);
             let deposit_args = match recipient_id {
                 BtcRecipient::Omni(recipient_id) => {
@@ -1451,7 +1391,6 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     .await
                     .unwrap();
             }
->>>>>>> main
         }
         OmniConnectorSubCommand::BtcVerifyWithdraw {
             chain,
@@ -1513,17 +1452,15 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             config_cli,
         } => {
             let btc_deposit_args = match recipient_id {
-                DepositRecipient::OmniBridge(recipient_id) => BtcDepositArgs::OmniDepositArgs {
+                BtcRecipient::Omni(recipient_id) => BtcDepositArgs::OmniDepositArgs {
                     recipient_id,
                     fee,
                     refund_address: Some(refund_address.clone()),
                 },
-                DepositRecipient::NearDirect(recipient_id) => {
-                    BtcDepositArgs::NearDirectDepositArgs {
-                        recipient_id,
-                        refund_address: Some(refund_address.clone()),
-                    }
-                }
+                BtcRecipient::Direct(recipient_id) => BtcDepositArgs::NearDirectDepositArgs {
+                    recipient_id,
+                    refund_address: Some(refund_address.clone()),
+                },
             };
             omni_connector(network, config_cli)
                 .btc_request_refund(

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -22,7 +22,10 @@ use solana_bridge_client::SolanaBridgeClientBuilder;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{signature::Keypair, signature::Signer as SolanaSigner, signer::EncodableKey};
 use starknet_bridge_client::StarknetBridgeClientBuilder;
-use utxo_bridge_client::{types::Bitcoin, types::Zcash, AuthOptions, UTXOBridgeClient};
+use utxo_bridge_client::{
+    types::{Bitcoin, PrefetchedTxData, Zcash},
+    AuthOptions, UTXOBridgeClient,
+};
 use wormhole_bridge_client::WormholeBridgeClientBuilder;
 
 use crate::{combined_config, fee, CliConfig, Network};
@@ -154,6 +157,86 @@ async fn resolve_evm_fees(
     let token = evm_address_to_omni(chain, token)?;
 
     fetch_indexer_fees(api_url, sender, token, amount, recipient).await
+}
+
+/// User-supplied bundle that lets us reconstruct the original `DepositMsg`
+/// locally instead of asking the bridge indexer. Pass `None` to
+/// `resolve_btc_deposit` when the caller wants full auto-discovery.
+struct ManualDepositInput {
+    recipient: BtcRecipient,
+    deposit_refund_address: Option<String>,
+    fee: u128,
+    safe_msg: Option<String>,
+}
+
+/// Resolve the `(BtcDepositArgs, vout, prefetched proof)` triple consumed by
+/// the BTC fin-transfer and refund flows.
+///
+/// - When `manual` is `Some`, builds `BtcDepositArgs` from the supplied
+///   recipient/fee/msg/refund and resolves `vout` either from the explicit
+///   value or by matching it against the derived deposit address.
+/// - When `manual` is `None`, asks the bridge indexer (via
+///   `resolve_deposit_from_tx`) which output is a tracked deposit address;
+///   the recovered `DepositMsg` is wrapped as `BtcDepositArgs::DepositMsg`.
+///
+/// In both paths the returned `PrefetchedTxData` lets downstream calls skip a
+/// redundant `extract_btc_proof` round-trip.
+async fn resolve_btc_deposit(
+    connector: &OmniConnector,
+    chain: ChainKind,
+    network: utxo_utils::address::Network,
+    btc_tx_hash: &str,
+    vout: Option<usize>,
+    manual: Option<ManualDepositInput>,
+) -> (BtcDepositArgs, usize, Option<PrefetchedTxData>) {
+    match manual {
+        Some(ManualDepositInput {
+            recipient,
+            deposit_refund_address,
+            fee,
+            safe_msg,
+        }) => {
+            let deposit_args = match recipient {
+                BtcRecipient::Omni(recipient_id) => {
+                    if safe_msg.is_some() {
+                        panic!("--msg is not supported with chain-prefixed recipient; use a direct NEAR account (e.g. 'foo.near') instead");
+                    }
+                    BtcDepositArgs::OmniDepositArgs {
+                        recipient_id,
+                        refund_address: deposit_refund_address,
+                        fee,
+                    }
+                }
+                BtcRecipient::Direct(account_id) => BtcDepositArgs::DepositMsg {
+                    msg: DepositMsg {
+                        recipient_id: account_id,
+                        post_actions: None,
+                        extra_msg: None,
+                        safe_deposit: safe_msg.map(|msg| SafeDepositMsg { msg }),
+                        refund_address: deposit_refund_address,
+                    },
+                },
+            };
+            let (v, p) = match vout {
+                Some(v) => (v, None),
+                None => {
+                    let (v, p) = connector
+                        .resolve_deposit_vout(chain, network, btc_tx_hash, &deposit_args)
+                        .await
+                        .unwrap();
+                    (v, Some(p))
+                }
+            };
+            (deposit_args, v, p)
+        }
+        None => {
+            let (v, found_msg, p) = connector
+                .resolve_deposit_from_tx(chain, network, btc_tx_hash, vout)
+                .await
+                .unwrap();
+            (BtcDepositArgs::DepositMsg { msg: found_msg }, v, Some(p))
+        }
+    }
 }
 
 async fn resolve_solana_fees(
@@ -535,15 +618,15 @@ pub enum OmniConnectorSubCommand {
         #[clap(
             short,
             long,
-            help = "The index of the output in the Bitcoin transaction. If omitted, it is auto-resolved by matching outputs against the deposit address derived from the recipient/fee/msg."
+            help = "The index of the output in the Bitcoin transaction. If omitted, it is auto-resolved (matched against the deposit address derived from the recipient/fee/msg, or — if no recipient is given — by asking the bridge indexer which output is a tracked deposit address). When --recipient-id is omitted and the tx has multiple tracked outputs, pass --vout to pick one."
         )]
         vout: Option<usize>,
         #[clap(
             short,
             long,
-            help = "The BTC recipient. With chain prefix (e.g. 'near:foo.near') routes via the Omni Bridge; without prefix (e.g. 'foo.near') makes a direct deposit to that NEAR account"
+            help = "The BTC recipient. With chain prefix (e.g. 'near:foo.near') routes via the Omni Bridge; without prefix (e.g. 'foo.near') makes a direct deposit to that NEAR account. If omitted, the deposit message is looked up from the bridge indexer by the tx's output address."
         )]
-        recipient_id: BtcRecipient,
+        recipient_id: Option<BtcRecipient>,
         #[clap(long, help = "Refund recipient address (Bitcoin/Zcash)")]
         refund_address: Option<String>,
         #[clap(
@@ -611,15 +694,15 @@ pub enum OmniConnectorSubCommand {
         #[clap(
             short,
             long,
-            help = "The index of the deposit output in the Bitcoin transaction. If omitted, it is auto-resolved by matching outputs against the deposit address derived from the recipient/fee/msg."
+            help = "The index of the deposit output in the Bitcoin transaction. If omitted, it is auto-resolved (matched against the deposit address derived from the recipient/fee/msg, or — if no recipient is given — by asking the bridge indexer which output is a tracked deposit address). When --recipient-id is omitted and the tx has multiple tracked outputs, pass --vout to pick one."
         )]
         vout: Option<usize>,
         #[clap(
             short,
             long,
-            help = "Original deposit recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit."
+            help = "Original deposit recipient. `<chain>:<address>` for an Omni-Bridge-routed deposit; a bare NEAR account (no colon) for a direct NEAR deposit. If omitted, the original deposit message is looked up from the bridge indexer by the tx's output address."
         )]
-        recipient_id: BtcRecipient,
+        recipient_id: Option<BtcRecipient>,
         #[clap(
             short,
             long,
@@ -1354,43 +1437,31 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             config_cli,
         } => {
             let connector = omni_connector(network, config_cli);
-            let deposit_args = match recipient_id {
-                BtcRecipient::Omni(recipient_id) => {
-                    if msg.is_some() {
-                        panic!("--msg is not supported with chain-prefixed recipient; use a direct NEAR account (e.g. 'foo.near') instead");
+
+            let manual = match recipient_id {
+                Some(recipient) => Some(ManualDepositInput {
+                    recipient,
+                    deposit_refund_address: refund_address,
+                    fee,
+                    safe_msg: msg,
+                }),
+                None => {
+                    if refund_address.is_some() || fee != 0 || msg.is_some() {
+                        panic!("--recipient-id is required when --refund-address, --fee, or --msg is supplied");
                     }
-                    BtcDepositArgs::OmniDepositArgs {
-                        recipient_id,
-                        refund_address,
-                        fee,
-                    }
+                    None
                 }
-                BtcRecipient::Direct(account_id) => BtcDepositArgs::DepositMsg {
-                    msg: DepositMsg {
-                        recipient_id: account_id,
-                        post_actions: None,
-                        extra_msg: None,
-                        safe_deposit: msg.map(|msg| SafeDepositMsg { msg }),
-                        refund_address,
-                    },
-                },
             };
 
-            let (resolved_vout, prefetched) = match vout {
-                Some(v) => (v, None),
-                None => {
-                    let (v, p) = connector
-                        .resolve_deposit_vout(
-                            chain.into(),
-                            network.into(),
-                            &btc_tx_hash,
-                            &deposit_args,
-                        )
-                        .await
-                        .unwrap();
-                    (v, Some(p))
-                }
-            };
+            let (deposit_args, resolved_vout, prefetched) = resolve_btc_deposit(
+                &connector,
+                chain.into(),
+                network.into(),
+                &btc_tx_hash,
+                vout,
+                manual,
+            )
+            .await;
 
             if dry_run {
                 let args = connector
@@ -1486,48 +1557,38 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             config_cli,
         } => {
             let connector = omni_connector(network, config_cli);
-            let deposit_refund_address = if no_deposit_refund_address {
-                None
-            } else {
-                Some(refund_address.clone())
-            };
-            let btc_deposit_args = match recipient_id {
-                BtcRecipient::Omni(recipient_id) => {
-                    if msg.is_some() {
-                        panic!("--msg is not supported with chain-prefixed recipient; use a direct NEAR account (e.g. 'foo.near') instead");
-                    }
-                    BtcDepositArgs::OmniDepositArgs {
-                        recipient_id,
-                        refund_address: deposit_refund_address,
+
+            let manual = match recipient_id {
+                Some(recipient) => {
+                    let deposit_refund_address = if no_deposit_refund_address {
+                        None
+                    } else {
+                        Some(refund_address.clone())
+                    };
+                    Some(ManualDepositInput {
+                        recipient,
+                        deposit_refund_address,
                         fee,
-                    }
+                        safe_msg: msg,
+                    })
                 }
-                BtcRecipient::Direct(account_id) => BtcDepositArgs::DepositMsg {
-                    msg: DepositMsg {
-                        recipient_id: account_id,
-                        post_actions: None,
-                        extra_msg: None,
-                        safe_deposit: msg.map(|msg| SafeDepositMsg { msg }),
-                        refund_address: deposit_refund_address,
-                    },
-                },
+                None => {
+                    if fee != 0 || msg.is_some() || no_deposit_refund_address {
+                        panic!("--recipient-id is required when --fee, --msg, or --no-deposit-refund-address is supplied");
+                    }
+                    None
+                }
             };
 
-            let (resolved_vout, prefetched) = match vout {
-                Some(v) => (v, None),
-                None => {
-                    let (v, p) = connector
-                        .resolve_deposit_vout(
-                            ChainKind::Btc,
-                            network.into(),
-                            &btc_tx_hash,
-                            &btc_deposit_args,
-                        )
-                        .await
-                        .unwrap();
-                    (v, Some(p))
-                }
-            };
+            let (btc_deposit_args, resolved_vout, prefetched) = resolve_btc_deposit(
+                &connector,
+                ChainKind::Btc,
+                network.into(),
+                &btc_tx_hash,
+                vout,
+                manual,
+            )
+            .await;
 
             connector
                 .btc_request_refund(

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -689,6 +689,12 @@ pub enum OmniConnectorSubCommand {
     },
     #[clap(about = "Request a refund for a never-finalized BTC deposit (Bitcoin only)")]
     BtcRequestRefund {
+        #[clap(
+            short,
+            long,
+            help = "Chain the deposit was made on. Only Bitcoin is currently supported; the flag exists for forward compatibility."
+        )]
+        chain: UTXOChainArg,
         #[clap(short, long, help = "Bitcoin deposit tx hash")]
         btc_tx_hash: String,
         #[clap(
@@ -710,8 +716,11 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         fee: u128,
-        #[clap(long, help = "BTC address to send the refund to")]
-        refund_address: String,
+        #[clap(
+            long,
+            help = "BTC address to send the refund to. Used only when the original DepositMsg does not carry a refund_address; if the deposit message has one, that value is used regardless. Required only when no refund_address was provided at deposit time."
+        )]
+        refund_address: Option<String>,
         #[clap(
             long,
             help = "Optional msg set as SafeDepositMsg.msg used at deposit time (only valid with direct recipient, i.e. without chain prefix)"
@@ -725,6 +734,11 @@ pub enum OmniConnectorSubCommand {
         no_deposit_refund_address: bool,
         #[clap(long, help = "Optional custom gas fee in satoshi (DAO/Operator only)")]
         gas_fee: Option<u128>,
+        #[clap(
+            long,
+            help = "Print the call args as JSON without submitting the transaction"
+        )]
+        dry_run: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1546,6 +1560,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .unwrap();
         }
         OmniConnectorSubCommand::BtcRequestRefund {
+            chain,
             btc_tx_hash,
             vout,
             recipient_id,
@@ -1554,8 +1569,14 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             msg,
             no_deposit_refund_address,
             gas_fee,
+            dry_run,
             config_cli,
         } => {
+            let chain_kind: ChainKind = chain.into();
+            if chain_kind != ChainKind::Btc {
+                panic!("btc-request-refund currently supports only --chain btc; got {chain:?}");
+            }
+
             let connector = omni_connector(network, config_cli);
 
             let manual = match recipient_id {
@@ -1563,7 +1584,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     let deposit_refund_address = if no_deposit_refund_address {
                         None
                     } else {
-                        Some(refund_address.clone())
+                        refund_address.clone()
                     };
                     Some(ManualDepositInput {
                         recipient,
@@ -1582,7 +1603,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
 
             let (btc_deposit_args, resolved_vout, prefetched) = resolve_btc_deposit(
                 &connector,
-                ChainKind::Btc,
+                chain_kind,
                 network.into(),
                 &btc_tx_hash,
                 vout,
@@ -1590,18 +1611,49 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             )
             .await;
 
-            connector
-                .btc_request_refund(
-                    btc_tx_hash,
-                    resolved_vout,
-                    btc_deposit_args,
-                    refund_address,
-                    gas_fee,
-                    prefetched,
-                    TransactionOptions::default(),
-                )
-                .await
-                .unwrap();
+            let deposit_msg_refund_address = match &btc_deposit_args {
+                BtcDepositArgs::DepositMsg { msg } => msg.refund_address.clone(),
+                BtcDepositArgs::OmniDepositArgs { refund_address, .. }
+                | BtcDepositArgs::NearDirectDepositArgs { refund_address, .. } => {
+                    refund_address.clone()
+                }
+            };
+            let final_refund_address = deposit_msg_refund_address
+                .or(refund_address)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "No refund destination: pass --refund-address (the deposit message has no refund_address)"
+                    )
+                });
+
+            if dry_run {
+                let args = connector
+                    .build_btc_request_refund_args(
+                        &btc_tx_hash,
+                        resolved_vout,
+                        btc_deposit_args,
+                        final_refund_address,
+                        gas_fee,
+                        prefetched,
+                    )
+                    .await
+                    .unwrap();
+                println!("method: request_refund");
+                println!("args: {}", serde_json::to_string_pretty(&args).unwrap());
+            } else {
+                connector
+                    .btc_request_refund(
+                        btc_tx_hash,
+                        resolved_vout,
+                        btc_deposit_args,
+                        final_refund_address,
+                        gas_fee,
+                        prefetched,
+                        TransactionOptions::default(),
+                    )
+                    .await
+                    .unwrap();
+            }
         }
         OmniConnectorSubCommand::BtcVerifyRefundFinalize {
             btc_tx_hash,

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -526,6 +526,11 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         fee: u128,
+        #[clap(
+            long,
+            help = "BTC refund address that was baked into the deposit_msg at deposit time (if any). Must match what was used in get-bitcoin-address."
+        )]
+        refund_address: Option<String>,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -631,6 +636,11 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         fee: u128,
+        #[clap(
+            long,
+            help = "Optional BTC refund address baked into the deposit_msg; use the same value when calling request-refund"
+        )]
+        refund_address: Option<String>,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1293,6 +1303,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             vout,
             recipient_id,
             fee,
+            refund_address,
             config_cli,
         } => {
             omni_connector(network, config_cli)
@@ -1300,7 +1311,11 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     chain_kind: chain.into(),
                     btc_tx_hash,
                     vout,
-                    btc_deposit_args: BtcDepositArgs::OmniDepositArgs { recipient_id, fee },
+                    btc_deposit_args: BtcDepositArgs::OmniDepositArgs {
+                        recipient_id,
+                        fee,
+                        refund_address,
+                    },
                     transaction_options: TransactionOptions::default(),
                 })
                 .await
@@ -1369,7 +1384,11 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .btc_request_refund(
                     btc_tx_hash,
                     vout,
-                    BtcDepositArgs::OmniDepositArgs { recipient_id, fee },
+                    BtcDepositArgs::OmniDepositArgs {
+                        recipient_id,
+                        fee,
+                        refund_address: Some(refund_address.clone()),
+                    },
                     refund_address,
                     gas_fee,
                     TransactionOptions::default(),
@@ -1408,11 +1427,12 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             chain,
             recipient_id,
             fee,
+            refund_address,
             config_cli,
         } => {
             let omni_connector = omni_connector(network, config_cli);
             let btc_address = omni_connector
-                .get_btc_address(chain.into(), &recipient_id, fee)
+                .get_btc_address(chain.into(), &recipient_id, fee, refund_address)
                 .await
                 .unwrap();
 

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -731,8 +731,30 @@ impl NearBridgeClient {
         chain: ChainKind,
         recipient_id: &OmniAddress,
         fee: u128,
+        refund_address: Option<String>,
     ) -> Result<String> {
-        let deposit_msg = self.get_deposit_msg_for_omni_bridge(recipient_id, fee)?;
+        let deposit_msg =
+            self.get_deposit_msg_for_omni_bridge(recipient_id, fee, refund_address)?;
+        self.get_btc_address_from_deposit_msg(chain, &deposit_msg).await
+    }
+
+    /// Fetch the BTC deposit address for a `DepositMsg` that mints nBTC directly
+    /// to a NEAR account (without the Omni Bridge wrapper).
+    pub async fn get_btc_address_for_near_account(
+        &self,
+        chain: ChainKind,
+        recipient_id: AccountId,
+        refund_address: Option<String>,
+    ) -> Result<String> {
+        let deposit_msg = self.get_deposit_msg_for_near_account(recipient_id, refund_address);
+        self.get_btc_address_from_deposit_msg(chain, &deposit_msg).await
+    }
+
+    async fn get_btc_address_from_deposit_msg(
+        &self,
+        chain: ChainKind,
+        deposit_msg: &DepositMsg,
+    ) -> Result<String> {
         let endpoint = self.endpoint()?;
         let btc_connector = self.utxo_chain_connector(chain)?;
 
@@ -901,6 +923,7 @@ impl NearBridgeClient {
         &self,
         recipient_id: &OmniAddress,
         fee: u128,
+        refund_address: Option<String>,
     ) -> Result<DepositMsg> {
         if recipient_id.is_utxo_chain() {
             return Err(BridgeSdkError::InvalidArgument(
@@ -912,7 +935,7 @@ impl NearBridgeClient {
             recipient_id: omni_bridge_id,
             post_actions: None,
             extra_msg: None,
-            refund_address: None,
+            refund_address,
             safe_deposit: Some(SafeDepositMsg {
                 msg: json!({
                     "UtxoFinTransfer": {
@@ -925,6 +948,22 @@ impl NearBridgeClient {
                 .to_string(),
             }),
         })
+    }
+
+    /// Build a `DepositMsg` that mints nBTC directly to a NEAR account, bypassing
+    /// the Omni Bridge safe-deposit wrapper.
+    pub fn get_deposit_msg_for_near_account(
+        &self,
+        recipient_id: AccountId,
+        refund_address: Option<String>,
+    ) -> DepositMsg {
+        DepositMsg {
+            recipient_id,
+            post_actions: None,
+            extra_msg: None,
+            safe_deposit: None,
+            refund_address,
+        }
     }
 
     pub async fn get_btc_tx_data(

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -28,6 +28,8 @@ const BTC_VERIFY_WITHDRAW_GAS: u64 = 300_000_000_000_000;
 const BTC_CANCEL_WITHDRAW_GAS: u64 = 300_000_000_000_000;
 const BTC_RBF_INCREASE_GAS_FEE_GAS: u64 = 300_000_000_000_000;
 const BTC_VERIFY_ACTIVE_UTXO_MANAGEMENT_GAS: u64 = 300_000_000_000_000;
+const BTC_REQUEST_REFUND_GAS: u64 = 300_000_000_000_000;
+const BTC_VERIFY_REFUND_FINALIZE_GAS: u64 = 300_000_000_000_000;
 const SUBMIT_BTC_TRANSFER_GAS: u64 = 300_000_000_000_000;
 
 const INIT_BTC_TRANSFER_DEPOSIT: u128 = 1;
@@ -39,6 +41,8 @@ const BTC_VERIFY_WITHDRAW_DEPOSIT: u128 = 0;
 const BTC_CANCEL_WITHDRAW_DEPOSIT: u128 = 1;
 const BTC_RBF_INCREASE_GAS_FEE_DEPOSIT: u128 = 0;
 const BTC_VERIFY_ACTIVE_UTXO_MANAGEMENT_DEPOSIT: u128 = 0;
+const BTC_REQUEST_REFUND_DEPOSIT: u128 = 0;
+const BTC_VERIFY_REFUND_FINALIZE_DEPOSIT: u128 = 0;
 const SUBMIT_BTC_TRANSFER_DEPOSIT: u128 = 0;
 pub const MAX_RATIO: u32 = 10000;
 
@@ -94,6 +98,8 @@ pub struct DepositMsg {
     pub extra_msg: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub safe_deposit: Option<SafeDepositMsg>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refund_address: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -108,6 +114,29 @@ pub struct FinBtcTransferArgs {
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BtcVerifyWithdrawArgs {
+    pub tx_id: String,
+    pub tx_block_blockhash: String,
+    pub tx_index: u64,
+    pub merkle_proof: Vec<String>,
+}
+
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct BtcRequestRefundArgs {
+    pub deposit_msg: DepositMsg,
+    pub refund_address: String,
+    pub tx_bytes: Vec<u8>,
+    pub vout: usize,
+    pub tx_block_blockhash: String,
+    pub tx_index: u64,
+    pub merkle_proof: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub gas_fee: Option<u128>,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct BtcVerifyRefundFinalizeArgs {
     pub tx_id: String,
     pub tx_block_blockhash: String,
     pub tx_index: u64,
@@ -559,6 +588,70 @@ impl NearBridgeClient {
         Ok(tx_hash)
     }
 
+    /// Submit a refund request for a never-finalized BTC deposit (Bitcoin only).
+    #[tracing::instrument(skip_all, name = "NEAR BTC REQUEST REFUND")]
+    pub async fn btc_request_refund(
+        &self,
+        args: BtcRequestRefundArgs,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let endpoint = self.endpoint()?;
+        let btc_connector = self.utxo_chain_connector(ChainKind::Btc)?;
+        let tx_hash = near_rpc_client::change_and_wait(
+            endpoint,
+            ChangeRequest {
+                signer: self.signer()?,
+                nonce: transaction_options.nonce,
+                receiver_id: btc_connector,
+                method_name: "request_refund".to_string(),
+                args: serde_json::json!(args).to_string().into_bytes(),
+                gas: BTC_REQUEST_REFUND_GAS,
+                deposit: BTC_REQUEST_REFUND_DEPOSIT,
+            },
+            transaction_options.wait_until,
+            transaction_options.wait_final_outcome_timeout_sec,
+        )
+        .await?;
+
+        tracing::info!(
+            tx_hash = tx_hash.to_string(),
+            "Sent BTC Request Refund transaction"
+        );
+        Ok(tx_hash)
+    }
+
+    /// Verify that the refund BTC transaction has been confirmed (Bitcoin only).
+    #[tracing::instrument(skip_all, name = "NEAR BTC VERIFY REFUND FINALIZE")]
+    pub async fn btc_verify_refund_finalize(
+        &self,
+        args: BtcVerifyRefundFinalizeArgs,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let endpoint = self.endpoint()?;
+        let btc_connector = self.utxo_chain_connector(ChainKind::Btc)?;
+        let tx_hash = near_rpc_client::change_and_wait(
+            endpoint,
+            ChangeRequest {
+                signer: self.signer()?,
+                nonce: transaction_options.nonce,
+                receiver_id: btc_connector,
+                method_name: "verify_refund_finalize".to_string(),
+                args: serde_json::json!(args).to_string().into_bytes(),
+                gas: BTC_VERIFY_REFUND_FINALIZE_GAS,
+                deposit: BTC_VERIFY_REFUND_FINALIZE_DEPOSIT,
+            },
+            transaction_options.wait_until,
+            transaction_options.wait_final_outcome_timeout_sec,
+        )
+        .await?;
+
+        tracing::info!(
+            tx_hash = tx_hash.to_string(),
+            "Sent BTC Verify Refund Finalize transaction"
+        );
+        Ok(tx_hash)
+    }
+
     #[tracing::instrument(skip_all, name = "ACTIVE UTXO MANAGEMENT")]
     pub async fn active_utxo_management(
         &self,
@@ -819,6 +912,7 @@ impl NearBridgeClient {
             recipient_id: omni_bridge_id,
             post_actions: None,
             extra_msg: None,
+            refund_address: None,
             safe_deposit: Some(SafeDepositMsg {
                 msg: json!({
                     "UtxoFinTransfer": {

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -864,13 +864,17 @@ impl NearBridgeClient {
         struct DepositAddressRequest {
             chain: String,
             recipient: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
             safe_deposit: Option<SafeDepositMsg>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            refund_address: Option<String>,
         }
 
         let request_body = DepositAddressRequest {
             chain: chain_name.to_string(),
             recipient: deposit_msg.recipient_id.to_string(),
             safe_deposit: deposit_msg.safe_deposit.clone(),
+            refund_address: deposit_msg.refund_address.clone(),
         };
 
         let client = reqwest::Client::builder()

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -838,7 +838,7 @@ impl NearBridgeClient {
         self.get_btc_address_from_deposit_msg(chain, &deposit_msg).await
     }
 
-    async fn get_btc_address_from_deposit_msg(
+    pub async fn get_btc_address_from_deposit_msg(
         &self,
         chain: ChainKind,
         deposit_msg: &DepositMsg,

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -877,38 +877,64 @@ impl NearBridgeClient {
             refund_address: deposit_msg.refund_address.clone(),
         };
 
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-            .map_err(|e| {
-                BridgeSdkError::UnknownError(format!("Failed to build HTTP client: {e}"))
-            })?;
-
-        let response = client
-            .post(api_url)
-            .json(&request_body)
-            .send()
-            .await
-            .map_err(|e| {
-                BridgeSdkError::UnknownError(format!(
-                    "Failed to fetch deposit address from bridge indexer: {e}"
-                ))
-            })?
-            .error_for_status()
-            .map_err(|e| {
-                BridgeSdkError::UnknownError(format!("Bridge indexer API returned error: {e}"))
-            })?;
-
         #[derive(serde::Deserialize)]
         struct DepositAddressResponse {
             address: String,
         }
 
-        let parsed: DepositAddressResponse = response.json().await.map_err(|e| {
-            BridgeSdkError::UnknownError(format!("Failed to parse deposit address response: {e}"))
-        })?;
+        let body = send_indexer_request(
+            reqwest::Client::new()
+                .post(api_url)
+                .timeout(std::time::Duration::from_secs(10))
+                .json(&request_body),
+        )
+        .await?;
+        let parsed: DepositAddressResponse = serde_json::from_str(&body)?;
 
         Ok(parsed.address)
+    }
+
+    /// Look up the `DepositMsg` that was stored by the bridge indexer when a
+    /// deposit address was issued.
+    ///
+    /// Returns `Ok(None)` if the indexer does not know the address (HTTP 404)
+    /// — caller treats this as "not a tracked deposit address". Any other
+    /// non-success status is reported as an error.
+    pub async fn get_deposit_msg_by_address(
+        &self,
+        chain: ChainKind,
+        address: &str,
+    ) -> Result<Option<DepositMsg>> {
+        let api_url = self
+            .bridge_indexer_api_url()?
+            .join("api/v3/utxo/get_deposit_message")
+            .map_err(|e| {
+                BridgeSdkError::ConfigError(format!("Failed to construct api endpoint url: {e}"))
+            })?;
+
+        let chain_name = match chain {
+            ChainKind::Btc => "btc",
+            ChainKind::Zcash => "zcash",
+            _ => {
+                return Err(BridgeSdkError::InvalidArgument(format!(
+                    "Unsupported UTXO chain: {chain:?}"
+                )))
+            }
+        };
+
+        let Some(body) = send_indexer_request_opt(
+            reqwest::Client::new()
+                .get(api_url)
+                .timeout(std::time::Duration::from_secs(10))
+                .query(&[("chain", chain_name), ("address", address)]),
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        let parsed: DepositMsg = serde_json::from_str(&body)?;
+
+        Ok(Some(parsed))
     }
 
     pub async fn get_utxo_num(&self, chain: ChainKind) -> Result<u32> {
@@ -1347,6 +1373,43 @@ impl NearBridgeClient {
     }
 }
 
+fn indexer_request_err(e: reqwest::Error) -> BridgeSdkError {
+    BridgeSdkError::BridgeIndexerError(e.to_string())
+}
+
+/// Send an HTTP request to the bridge indexer and return the response body
+/// as text. Any non-success status (including 404) is reported as an error.
+async fn send_indexer_request(request: reqwest::RequestBuilder) -> Result<String> {
+    request
+        .send()
+        .await
+        .map_err(indexer_request_err)?
+        .error_for_status()
+        .map_err(indexer_request_err)?
+        .text()
+        .await
+        .map_err(indexer_request_err)
+}
+
+/// Like `send_indexer_request`, but maps HTTP 404 to `Ok(None)` so the caller
+/// can distinguish "the indexer doesn't track this resource" from a real
+/// transport / 5xx failure.
+async fn send_indexer_request_opt(
+    request: reqwest::RequestBuilder,
+) -> Result<Option<String>> {
+    let response = request.send().await.map_err(indexer_request_err)?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    response
+        .error_for_status()
+        .map_err(indexer_request_err)?
+        .text()
+        .await
+        .map(Some)
+        .map_err(indexer_request_err)
+}
+
 #[cfg(test)]
 mod tests {
     use bridge_connector_common::result::BridgeSdkError;
@@ -1525,8 +1588,8 @@ mod tests {
             .expect_err("500 status should fail");
 
         assert!(
-            matches!(err, BridgeSdkError::UnknownError(_)),
-            "expected UnknownError, got {err:?}"
+            matches!(err, BridgeSdkError::BridgeIndexerError(_)),
+            "expected BridgeIndexerError, got {err:?}"
         );
     }
 

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-bridge-client"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/src/types.rs
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/src/types.rs
@@ -20,6 +20,17 @@ pub struct TxProof {
     pub merkle_proof: Vec<String>,
 }
 
+/// Bundle of work already done for a deposit BTC tx — the network-fetched
+/// `TxProof` together with its parsed `bitcoin::Transaction`. Produced by
+/// `resolve_deposit_vout` and threaded into a follow-up
+/// `build_fin_btc_transfer_args` / `btc_request_refund` to skip a second
+/// `extract_btc_proof` round-trip and a second tx-bytes parse.
+#[derive(Debug)]
+pub struct PrefetchedTxData {
+    pub proof: TxProof,
+    pub parsed_tx: bitcoin::Transaction,
+}
+
 pub struct UtxoBridgeTransactionData {
     pub tx_hash: String,
     pub deposit_address: String,

--- a/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
+++ b/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-connector-common"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/bridge-connector-common/src/result.rs
+++ b/bridge-sdk/connectors/bridge-connector-common/src/result.rs
@@ -39,6 +39,8 @@ pub enum BridgeSdkError {
     UtxoClientError(String),
     #[error("Error communicating with Utxo chain RPC: {0}")]
     UtxoRpcError(String),
+    #[error("Bridge indexer API error: {0}")]
+    BridgeIndexerError(String),
     #[error("Insufficient UTXO chain Gas Fee: {0}")]
     InsufficientUTXOGasFee(String),
     #[error("Insufficient UTXO balance to cover amount and fees")]

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -46,7 +46,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::OnceLock;
 use utxo_bridge_client::{
-    types::{Bitcoin, Zcash},
+    types::{Bitcoin, PrefetchedTxData, Zcash},
     UTXOBridgeClient,
 };
 use utxo_utils::{get_gas_fee, UTXO};
@@ -261,6 +261,10 @@ pub enum FinTransferArgs {
         btc_tx_hash: String,
         vout: usize,
         btc_deposit_args: BtcDepositArgs,
+        /// Data already fetched/parsed by a prior `resolve_deposit_vout` call.
+        /// When `Some`, skips a redundant `extract_btc_proof` round-trip and
+        /// a second `tx_bytes` parse.
+        prefetched: Option<PrefetchedTxData>,
         transaction_options: TransactionOptions,
     },
     EvmFinTransfer {
@@ -570,11 +574,25 @@ impl OmniConnector {
         tx_hash: String,
         vout: usize,
         deposit_args: BtcDepositArgs,
+        prefetched: Option<PrefetchedTxData>,
     ) -> Result<FinBtcTransferArgs> {
-        let utxo_bridge_client = self.utxo_bridge_client(chain)?;
         let near_bridge_client = self.near_bridge_client()?;
 
-        let proof_data = utxo_bridge_client.extract_btc_proof(&tx_hash).await?;
+        let PrefetchedTxData {
+            proof: proof_data,
+            parsed_tx: btc_tx,
+        } = match prefetched {
+            Some(p) => p,
+            None => {
+                let proof = self
+                    .utxo_bridge_client(chain)?
+                    .extract_btc_proof(&tx_hash)
+                    .await?;
+                let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
+                    .map_err(BridgeSdkError::InvalidArgument)?;
+                PrefetchedTxData { proof, parsed_tx }
+            }
+        };
 
         let deposit_msg = match deposit_args {
             BtcDepositArgs::DepositMsg { msg } => msg,
@@ -594,8 +612,6 @@ impl OmniConnector {
                 .get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
-        let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
-            .map_err(BridgeSdkError::InvalidArgument)?;
         let deposit_output = btc_tx.output.get(vout).ok_or_else(|| {
             BridgeSdkError::InvalidArgument(format!(
                 "vout {vout} out of range; tx has {} outputs",
@@ -634,10 +650,11 @@ impl OmniConnector {
         tx_hash: String,
         vout: usize,
         deposit_args: BtcDepositArgs,
+        prefetched: Option<PrefetchedTxData>,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
         let args = self
-            .build_fin_btc_transfer_args(chain, tx_hash, vout, deposit_args)
+            .build_fin_btc_transfer_args(chain, tx_hash, vout, deposit_args, prefetched)
             .await?;
 
         self.near_bridge_client()?
@@ -737,15 +754,27 @@ impl OmniConnector {
         deposit_args: BtcDepositArgs,
         refund_address: String,
         gas_fee: Option<u128>,
+        prefetched: Option<PrefetchedTxData>,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
-        let utxo_bridge_client = self.utxo_bridge_client(ChainKind::Btc)?;
         let near_bridge_client = self.near_bridge_client()?;
 
-        let proof_data = utxo_bridge_client.extract_btc_proof(&btc_tx_hash).await?;
+        let PrefetchedTxData {
+            proof: proof_data,
+            parsed_tx: btc_tx,
+        } = match prefetched {
+            Some(p) => p,
+            None => {
+                let proof = self
+                    .utxo_bridge_client(ChainKind::Btc)?
+                    .extract_btc_proof(&btc_tx_hash)
+                    .await?;
+                let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
+                    .map_err(BridgeSdkError::InvalidArgument)?;
+                PrefetchedTxData { proof, parsed_tx }
+            }
+        };
 
-        let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
-            .map_err(BridgeSdkError::InvalidArgument)?;
         let deposit_output = btc_tx.output.get(vout).ok_or_else(|| {
             BridgeSdkError::InvalidArgument(format!(
                 "vout {vout} out of range; tx has {} outputs",
@@ -878,13 +907,18 @@ impl OmniConnector {
     ///
     /// Returns `InvalidArgument` if no output matches or if multiple outputs
     /// match (in which case the candidate vouts are listed in the message).
+    ///
+    /// Also returns the fetched `TxProof` and the parsed transaction so
+    /// callers can hand them to a follow-up `build_fin_btc_transfer_args` /
+    /// `btc_request_refund` and avoid re-fetching the proof / re-parsing the
+    /// tx bytes.
     pub async fn resolve_deposit_vout(
         &self,
         chain: ChainKind,
         network: Network,
         tx_hash: &str,
         deposit_args: &BtcDepositArgs,
-    ) -> Result<usize> {
+    ) -> Result<(usize, PrefetchedTxData)> {
         let expected_address = match deposit_args {
             BtcDepositArgs::OmniDepositArgs {
                 recipient_id,
@@ -923,15 +957,15 @@ impl OmniConnector {
                 ))
             })?;
 
-        let proof_data = self
+        let proof = self
             .utxo_bridge_client(chain)?
             .extract_btc_proof(tx_hash)
             .await?;
 
-        let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
+        let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
             .map_err(BridgeSdkError::InvalidArgument)?;
 
-        let matches: Vec<usize> = btc_tx
+        let matches: Vec<usize> = parsed_tx
             .output
             .iter()
             .enumerate()
@@ -942,7 +976,7 @@ impl OmniConnector {
             [] => Err(BridgeSdkError::InvalidArgument(format!(
                 "No output in tx {tx_hash} matches deposit address `{expected_address}`. Verify the recipient/fee/msg match the original deposit."
             ))),
-            [v] => Ok(*v),
+            [v] => Ok((*v, PrefetchedTxData { proof, parsed_tx })),
             many => Err(BridgeSdkError::InvalidArgument(format!(
                 "Ambiguous: multiple outputs in tx {tx_hash} match deposit address `{expected_address}`. Re-run with vout set to one of: {many:?}"
             ))),
@@ -2590,6 +2624,7 @@ impl OmniConnector {
                 btc_tx_hash,
                 vout,
                 btc_deposit_args,
+                prefetched,
                 transaction_options,
             } => self
                 .near_fin_transfer_btc(
@@ -2597,6 +2632,7 @@ impl OmniConnector {
                     btc_tx_hash,
                     vout,
                     btc_deposit_args,
+                    prefetched,
                     transaction_options,
                 )
                 .await

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -983,6 +983,85 @@ impl OmniConnector {
         }
     }
 
+    /// Auto-resolve the deposit `vout` and the original `DepositMsg` from
+    /// `tx_hash` alone, by asking the bridge indexer
+    /// (`GET /api/v3/utxo/get_deposit_message`) about each output's address.
+    ///
+    /// When `prefer_vout` is `None`, the unique tracked output is returned —
+    /// or `InvalidArgument` if zero or multiple outputs match.
+    ///
+    /// When `prefer_vout` is `Some(v)`, the result is filtered to vout `v`
+    /// (use this to disambiguate a tx with multiple tracked outputs without
+    /// having to supply the full deposit args). Errors if vout `v` is not a
+    /// tracked deposit address.
+    pub async fn resolve_deposit_from_tx(
+        &self,
+        chain: ChainKind,
+        network: Network,
+        tx_hash: &str,
+        prefer_vout: Option<usize>,
+    ) -> Result<(usize, DepositMsg, PrefetchedTxData)> {
+        let near_bridge_client = self.near_bridge_client()?;
+
+        let proof = self
+            .utxo_bridge_client(chain)?
+            .extract_btc_proof(tx_hash)
+            .await?;
+
+        let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
+            .map_err(BridgeSdkError::InvalidArgument)?;
+
+        if let Some(v) = prefer_vout {
+            let out = parsed_tx.output.get(v).ok_or_else(|| {
+                BridgeSdkError::InvalidArgument(format!(
+                    "vout {v} out of range; tx {tx_hash} has {} outputs",
+                    parsed_tx.output.len()
+                ))
+            })?;
+            let addr = UTXOAddress::from_script(&out.script_pubkey, chain, network)
+                .ok_or_else(|| {
+                    BridgeSdkError::InvalidArgument(format!(
+                        "vout {v} in tx {tx_hash} has an unrecognized script_pubkey"
+                    ))
+                })?;
+            let msg = near_bridge_client
+                .get_deposit_msg_by_address(chain, &addr.to_string())
+                .await?
+                .ok_or_else(|| {
+                    BridgeSdkError::InvalidArgument(format!(
+                        "vout {v} in tx {tx_hash} is not a deposit address tracked by the bridge indexer"
+                    ))
+                })?;
+            return Ok((v, msg, PrefetchedTxData { proof, parsed_tx }));
+        }
+
+        let mut found: Option<(usize, DepositMsg)> = None;
+        for (i, out) in parsed_tx.output.iter().enumerate() {
+            let Some(addr) = UTXOAddress::from_script(&out.script_pubkey, chain, network) else {
+                continue;
+            };
+            let Some(msg) = near_bridge_client
+                .get_deposit_msg_by_address(chain, &addr.to_string())
+                .await?
+            else {
+                continue;
+            };
+            if let Some((prev_v, _)) = &found {
+                return Err(BridgeSdkError::InvalidArgument(format!(
+                    "Ambiguous: outputs at vouts {prev_v} and {i} in tx {tx_hash} are both tracked deposit addresses. Re-run with --vout to pick one."
+                )));
+            }
+            found = Some((i, msg));
+        }
+
+        let (vout, msg) = found.ok_or_else(|| {
+            BridgeSdkError::InvalidArgument(format!(
+                "No output in tx {tx_hash} matches a deposit address tracked by the bridge indexer. Pass deposit args explicitly to disambiguate."
+            ))
+        })?;
+        Ok((vout, msg, PrefetchedTxData { proof, parsed_tx }))
+    }
+
     pub async fn active_utxo_management(
         &self,
         chain: ChainKind,

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -766,18 +766,18 @@ impl OmniConnector {
             BtcDepositArgs::DepositMsg { msg } => msg,
             BtcDepositArgs::OmniDepositArgs {
                 recipient_id,
-                refund_address,
+                refund_address: deposit_refund_address,
                 fee,
             } => near_bridge_client.get_deposit_msg_for_omni_bridge(
                 &recipient_id,
-                refund_address,
+                deposit_refund_address,
                 fee,
             )?,
             BtcDepositArgs::NearDirectDepositArgs {
                 recipient_id,
-                refund_address,
+                refund_address: deposit_refund_address,
             } => near_bridge_client
-                .get_deposit_msg_for_near_account(recipient_id, refund_address),
+                .get_deposit_msg_for_near_account(recipient_id, deposit_refund_address),
         };
 
         let args = BtcRequestRefundArgs {

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -872,6 +872,83 @@ impl OmniConnector {
             .await
     }
 
+    /// Resolve the deposit `vout` by matching outputs of the BTC/Zcash tx
+    /// `tx_hash` against the deposit address derived from `deposit_args` via
+    /// the bridge indexer.
+    ///
+    /// Returns `InvalidArgument` if no output matches or if multiple outputs
+    /// match (in which case the candidate vouts are listed in the message).
+    pub async fn resolve_deposit_vout(
+        &self,
+        chain: ChainKind,
+        network: Network,
+        tx_hash: &str,
+        deposit_args: &BtcDepositArgs,
+    ) -> Result<usize> {
+        let expected_address = match deposit_args {
+            BtcDepositArgs::OmniDepositArgs {
+                recipient_id,
+                refund_address,
+                fee,
+            } => {
+                self.get_btc_address(chain, recipient_id, refund_address.clone(), *fee)
+                    .await?
+            }
+            BtcDepositArgs::NearDirectDepositArgs {
+                recipient_id,
+                refund_address,
+            } => {
+                self.get_btc_address_for_near_account(
+                    chain,
+                    recipient_id.clone(),
+                    refund_address.clone(),
+                )
+                .await?
+            }
+            BtcDepositArgs::DepositMsg { msg } => {
+                self.get_btc_address_from_deposit_msg(chain, msg).await?
+            }
+        };
+
+        let expected_script = UTXOAddress::parse(&expected_address, chain, network)
+            .map_err(|e| {
+                BridgeSdkError::InvalidArgument(format!(
+                    "Failed to parse deposit address `{expected_address}`: {e}"
+                ))
+            })?
+            .script_pubkey()
+            .map_err(|e| {
+                BridgeSdkError::InvalidArgument(format!(
+                    "Failed to derive script_pubkey for `{expected_address}`: {e}"
+                ))
+            })?;
+
+        let proof_data = self
+            .utxo_bridge_client(chain)?
+            .extract_btc_proof(tx_hash)
+            .await?;
+
+        let btc_tx = utxo_utils::try_bytes_to_btc_transaction(&proof_data.tx_bytes)
+            .map_err(BridgeSdkError::InvalidArgument)?;
+
+        let matches: Vec<usize> = btc_tx
+            .output
+            .iter()
+            .enumerate()
+            .filter_map(|(i, out)| (out.script_pubkey == expected_script).then_some(i))
+            .collect();
+
+        match matches.as_slice() {
+            [] => Err(BridgeSdkError::InvalidArgument(format!(
+                "No output in tx {tx_hash} matches deposit address `{expected_address}`. Verify the recipient/fee/msg match the original deposit."
+            ))),
+            [v] => Ok(*v),
+            many => Err(BridgeSdkError::InvalidArgument(format!(
+                "Ambiguous: multiple outputs in tx {tx_hash} match deposit address `{expected_address}`. Re-run with vout set to one of: {many:?}"
+            ))),
+        }
+    }
+
     pub async fn active_utxo_management(
         &self,
         chain: ChainKind,

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -295,6 +295,7 @@ pub enum BtcDepositArgs {
     OmniDepositArgs {
         recipient_id: OmniAddress,
         fee: u128,
+        refund_address: Option<String>,
     },
     DepositMsg {
         msg: DepositMsg,
@@ -576,9 +577,21 @@ impl OmniConnector {
 
         let deposit_msg = match deposit_args {
             BtcDepositArgs::DepositMsg { msg } => msg,
-            BtcDepositArgs::OmniDepositArgs { recipient_id, fee } => {
-                near_bridge_client.get_deposit_msg_for_omni_bridge(&recipient_id, fee)?
-            }
+            BtcDepositArgs::OmniDepositArgs {
+                recipient_id: OmniAddress::Near(account_id),
+                fee: _,
+                refund_address,
+            } => near_bridge_client
+                .get_deposit_msg_for_near_account(account_id, refund_address),
+            BtcDepositArgs::OmniDepositArgs {
+                recipient_id,
+                fee,
+                refund_address,
+            } => near_bridge_client.get_deposit_msg_for_omni_bridge(
+                &recipient_id,
+                fee,
+                refund_address,
+            )?,
         };
 
         let args = FinBtcTransferArgs {
@@ -705,9 +718,21 @@ impl OmniConnector {
 
         let deposit_msg = match deposit_args {
             BtcDepositArgs::DepositMsg { msg } => msg,
-            BtcDepositArgs::OmniDepositArgs { recipient_id, fee } => {
-                near_bridge_client.get_deposit_msg_for_omni_bridge(&recipient_id, fee)?
-            }
+            BtcDepositArgs::OmniDepositArgs {
+                recipient_id: OmniAddress::Near(account_id),
+                fee: _,
+                refund_address,
+            } => near_bridge_client
+                .get_deposit_msg_for_near_account(account_id, refund_address),
+            BtcDepositArgs::OmniDepositArgs {
+                recipient_id,
+                fee,
+                refund_address,
+            } => near_bridge_client.get_deposit_msg_for_omni_bridge(
+                &recipient_id,
+                fee,
+                refund_address,
+            )?,
         };
 
         let args = BtcRequestRefundArgs {
@@ -765,10 +790,25 @@ impl OmniConnector {
         chain: ChainKind,
         recipient_id: &OmniAddress,
         fee: u128,
+        refund_address: Option<String>,
     ) -> Result<String> {
         let near_bridge_client = self.near_bridge_client()?;
         near_bridge_client
-            .get_btc_address(chain, recipient_id, fee)
+            .get_btc_address(chain, recipient_id, fee, refund_address)
+            .await
+    }
+
+    /// Fetch a BTC deposit address that mints nBTC directly to a NEAR account,
+    /// bypassing the Omni Bridge wrapper.
+    pub async fn get_btc_address_for_near_account(
+        &self,
+        chain: ChainKind,
+        recipient_id: AccountId,
+        refund_address: Option<String>,
+    ) -> Result<String> {
+        let near_bridge_client = self.near_bridge_client()?;
+        near_bridge_client
+            .get_btc_address_for_near_account(chain, recipient_id, refund_address)
             .await
     }
 
@@ -1581,7 +1621,7 @@ impl OmniConnector {
         let utxo_bridge_client = self.utxo_bridge_client(chain_kind)?;
 
         let deposit_address = near_bridge_client
-            .get_btc_address(chain_kind, &recipient, fee)
+            .get_btc_address(chain_kind, &recipient, fee, None)
             .await?;
         let tx_data = utxo_bridge_client
             .get_bridge_transaction_data(&tx_hash, &deposit_address)

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -292,9 +292,17 @@ pub enum FinTransferArgs {
 }
 
 pub enum BtcDepositArgs {
+    /// Deposit routed through the Omni Bridge (nBTC is minted to the bridge account,
+    /// which then forwards it to `recipient_id` on the destination chain).
     OmniDepositArgs {
         recipient_id: OmniAddress,
         fee: u128,
+        refund_address: Option<String>,
+    },
+    /// Direct NEAR deposit: nBTC is minted straight to `recipient_id`, bypassing
+    /// the Omni Bridge wrapper.
+    NearDirectDepositArgs {
+        recipient_id: AccountId,
         refund_address: Option<String>,
     },
     DepositMsg {
@@ -578,12 +586,6 @@ impl OmniConnector {
         let deposit_msg = match deposit_args {
             BtcDepositArgs::DepositMsg { msg } => msg,
             BtcDepositArgs::OmniDepositArgs {
-                recipient_id: OmniAddress::Near(account_id),
-                fee: _,
-                refund_address,
-            } => near_bridge_client
-                .get_deposit_msg_for_near_account(account_id, refund_address),
-            BtcDepositArgs::OmniDepositArgs {
                 recipient_id,
                 fee,
                 refund_address,
@@ -592,6 +594,11 @@ impl OmniConnector {
                 fee,
                 refund_address,
             )?,
+            BtcDepositArgs::NearDirectDepositArgs {
+                recipient_id,
+                refund_address,
+            } => near_bridge_client
+                .get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
         let args = FinBtcTransferArgs {
@@ -719,12 +726,6 @@ impl OmniConnector {
         let deposit_msg = match deposit_args {
             BtcDepositArgs::DepositMsg { msg } => msg,
             BtcDepositArgs::OmniDepositArgs {
-                recipient_id: OmniAddress::Near(account_id),
-                fee: _,
-                refund_address,
-            } => near_bridge_client
-                .get_deposit_msg_for_near_account(account_id, refund_address),
-            BtcDepositArgs::OmniDepositArgs {
                 recipient_id,
                 fee,
                 refund_address,
@@ -733,6 +734,11 @@ impl OmniConnector {
                 fee,
                 refund_address,
             )?,
+            BtcDepositArgs::NearDirectDepositArgs {
+                recipient_id,
+                refund_address,
+            } => near_bridge_client
+                .get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
         let args = BtcRequestRefundArgs {

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -30,8 +30,8 @@ use omni_types::{
 
 use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
 use near_bridge_client::btc::{
-    BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg, FinBtcTransferArgs,
-    NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
+    BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs, BtcVerifyWithdrawArgs, ChainSpecificData,
+    DepositMsg, FinBtcTransferArgs, NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
 };
 use near_bridge_client::{Decimals, NearBridgeClient, TransactionOptions};
 use solana_bridge_client::{
@@ -673,6 +673,90 @@ impl OmniConnector {
 
         near_bridge_client
             .btc_verify_active_utxo_management(chain, args, transaction_options)
+            .await
+    }
+
+    /// Submit a refund request for a never-finalized BTC deposit. Bitcoin only.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn btc_request_refund(
+        &self,
+        btc_tx_hash: String,
+        vout: usize,
+        deposit_args: BtcDepositArgs,
+        refund_address: String,
+        gas_fee: Option<u128>,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let utxo_bridge_client = self.utxo_bridge_client(ChainKind::Btc)?;
+        let near_bridge_client = self.near_bridge_client()?;
+
+        let proof_data = utxo_bridge_client.extract_btc_proof(&btc_tx_hash).await?;
+
+        let light_client = self.light_client(ChainKind::Btc)?;
+        let light_client_last_block = light_client.get_last_block_number().await?;
+
+        let confirmations = near_bridge_client.get_confirmations(ChainKind::Btc).await?;
+
+        if proof_data.block_height + u64::from(confirmations) > light_client_last_block {
+            return Err(BridgeSdkError::LightClientNotSynced(
+                light_client_last_block,
+            ));
+        }
+
+        let deposit_msg = match deposit_args {
+            BtcDepositArgs::DepositMsg { msg } => msg,
+            BtcDepositArgs::OmniDepositArgs { recipient_id, fee } => {
+                near_bridge_client.get_deposit_msg_for_omni_bridge(&recipient_id, fee)?
+            }
+        };
+
+        let args = BtcRequestRefundArgs {
+            deposit_msg,
+            refund_address,
+            tx_bytes: proof_data.tx_bytes,
+            vout,
+            tx_block_blockhash: proof_data.tx_block_blockhash,
+            tx_index: proof_data.tx_index,
+            merkle_proof: proof_data.merkle_proof,
+            gas_fee,
+        };
+
+        near_bridge_client
+            .btc_request_refund(args, transaction_options)
+            .await
+    }
+
+    /// Verify that the refund BTC transaction has been confirmed on Bitcoin. Bitcoin only.
+    pub async fn btc_verify_refund_finalize(
+        &self,
+        btc_tx_hash: String,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let utxo_bridge_client = self.utxo_bridge_client(ChainKind::Btc)?;
+        let near_bridge_client = self.near_bridge_client()?;
+
+        let proof_data = utxo_bridge_client.extract_btc_proof(&btc_tx_hash).await?;
+
+        let light_client = self.light_client(ChainKind::Btc)?;
+        let light_client_last_block = light_client.get_last_block_number().await?;
+
+        let confirmations = near_bridge_client.get_confirmations(ChainKind::Btc).await?;
+
+        if proof_data.block_height + u64::from(confirmations) > light_client_last_block {
+            return Err(BridgeSdkError::LightClientNotSynced(
+                light_client_last_block,
+            ));
+        }
+
+        let args = BtcVerifyRefundFinalizeArgs {
+            tx_id: btc_tx_hash,
+            tx_block_blockhash: proof_data.tx_block_blockhash,
+            tx_index: proof_data.tx_index,
+            merkle_proof: proof_data.merkle_proof,
+        };
+
+        near_bridge_client
+            .btc_verify_refund_finalize(args, transaction_options)
             .await
     }
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -771,7 +771,7 @@ impl OmniConnector {
             } => near_bridge_client.get_deposit_msg_for_omni_bridge(
                 &recipient_id,
                 refund_address,
-                fee,            
+                fee,
             )?,
             BtcDepositArgs::NearDirectDepositArgs {
                 recipient_id,

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -858,6 +858,20 @@ impl OmniConnector {
             .await
     }
 
+    /// Fetch the BTC deposit address for an arbitrary `DepositMsg` (including
+    /// custom `safe_deposit.msg`). Use this when neither `get_btc_address` nor
+    /// `get_btc_address_for_near_account` covers the exact `DepositMsg` shape.
+    pub async fn get_btc_address_from_deposit_msg(
+        &self,
+        chain: ChainKind,
+        deposit_msg: &DepositMsg,
+    ) -> Result<String> {
+        let near_bridge_client = self.near_bridge_client()?;
+        near_bridge_client
+            .get_btc_address_from_deposit_msg(chain, deposit_msg)
+            .await
+    }
+
     pub async fn active_utxo_management(
         &self,
         chain: ChainKind,

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -745,18 +745,19 @@ impl OmniConnector {
             .await
     }
 
-    /// Submit a refund request for a never-finalized BTC deposit. Bitcoin only.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn btc_request_refund(
+    /// Build the args for a BTC refund request without submitting the
+    /// transaction. Bitcoin only. The `prefetched` proof can be supplied by a
+    /// prior `resolve_deposit_vout` / `resolve_deposit_from_tx` call to skip
+    /// the redundant `extract_btc_proof`.
+    pub async fn build_btc_request_refund_args(
         &self,
-        btc_tx_hash: String,
+        btc_tx_hash: &str,
         vout: usize,
         deposit_args: BtcDepositArgs,
         refund_address: String,
         gas_fee: Option<u128>,
         prefetched: Option<PrefetchedTxData>,
-        transaction_options: TransactionOptions,
-    ) -> Result<CryptoHash> {
+    ) -> Result<BtcRequestRefundArgs> {
         let near_bridge_client = self.near_bridge_client()?;
 
         let PrefetchedTxData {
@@ -767,7 +768,7 @@ impl OmniConnector {
             None => {
                 let proof = self
                     .utxo_bridge_client(ChainKind::Btc)?
-                    .extract_btc_proof(&btc_tx_hash)
+                    .extract_btc_proof(btc_tx_hash)
                     .await?;
                 let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
                     .map_err(BridgeSdkError::InvalidArgument)?;
@@ -809,7 +810,7 @@ impl OmniConnector {
                 .get_deposit_msg_for_near_account(recipient_id, deposit_refund_address),
         };
 
-        let args = BtcRequestRefundArgs {
+        Ok(BtcRequestRefundArgs {
             deposit_msg,
             refund_address,
             tx_bytes: proof_data.tx_bytes,
@@ -818,9 +819,33 @@ impl OmniConnector {
             tx_index: proof_data.tx_index,
             merkle_proof: proof_data.merkle_proof,
             gas_fee,
-        };
+        })
+    }
 
-        near_bridge_client
+    /// Submit a refund request for a never-finalized BTC deposit. Bitcoin only.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn btc_request_refund(
+        &self,
+        btc_tx_hash: String,
+        vout: usize,
+        deposit_args: BtcDepositArgs,
+        refund_address: String,
+        gas_fee: Option<u128>,
+        prefetched: Option<PrefetchedTxData>,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let args = self
+            .build_btc_request_refund_args(
+                &btc_tx_hash,
+                vout,
+                deposit_args,
+                refund_address,
+                gas_fee,
+                prefetched,
+            )
+            .await?;
+
+        self.near_bridge_client()?
             .btc_request_refund(args, transaction_options)
             .await
     }


### PR DESCRIPTION
- Added CLI commands to refund never-finalized BTC deposits (`btc-request-refund`, `btc-verify-refund-finalize`)
- Added a README walkthrough for the full refund pipeline
- `vout` is now auto-resolved from the derived deposit address (in both `btc-request-refund` and `btc-fin-transfer`)
- Fixed a bug where `refund_address` was not sent to the indexer when fetching the deposit address, causing the wrong address to be returned
