### PR TITLE
fix(starknet): support RPC providers that require positional params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10122,8 +10122,11 @@ dependencies = [
 name = "starknet-bridge-client"
 version = "0.1.2"
 dependencies = [
+ "async-trait",
  "hex",
  "omni-types",
+ "reqwest",
+ "serde",
  "serde_json",
  "starknet",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10120,7 +10120,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-bridge-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "hex",

--- a/bridge-sdk/bridge-clients/starknet-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/starknet-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-bridge-client"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/bridge-clients/starknet-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/starknet-bridge-client/Cargo.toml
@@ -10,8 +10,11 @@ thiserror.workspace = true
 tracing.workspace = true
 omni-types.workspace = true
 hex.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+reqwest.workspace = true
 tokio.workspace = true
+async-trait = "0.1"
 url = "2"
 
 [lib]

--- a/bridge-sdk/bridge-clients/starknet-bridge-client/src/builder.rs
+++ b/bridge-sdk/bridge-clients/starknet-bridge-client/src/builder.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use starknet::{
     accounts::{ExecutionEncoding, SingleOwnerAccount},
     core::types::{BlockId, BlockTag, Felt},
-    providers::{jsonrpc::HttpTransport, JsonRpcClient},
+    providers::JsonRpcClient,
     signers::{LocalWallet, SigningKey},
 };
 use url::Url;
 
 use crate::error::{Result, StarknetBridgeClientError};
+use crate::rpc_transport::PositionalHttpTransport;
 use crate::StarknetBridgeClient;
 
 #[derive(Default)]
@@ -65,7 +66,7 @@ impl StarknetBridgeClientBuilder {
             StarknetBridgeClientError::ConfigError("Invalid Starknet RPC endpoint URL".to_string())
         })?;
 
-        let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(url)));
+        let provider = Arc::new(JsonRpcClient::new(PositionalHttpTransport::new(url)));
 
         let account = if let (Some(pk), Some(addr)) = (self.private_key, self.account_address) {
             let private_key = parse_felt(&pk).map_err(|_| {

--- a/bridge-sdk/bridge-clients/starknet-bridge-client/src/rpc_transport.rs
+++ b/bridge-sdk/bridge-clients/starknet-bridge-client/src/rpc_transport.rs
@@ -1,0 +1,190 @@
+use async_trait::async_trait;
+use reqwest::{Client, Url};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use starknet::providers::{
+    jsonrpc::{HttpTransportError, JsonRpcError, JsonRpcMethod, JsonRpcResponse, JsonRpcTransport},
+    ProviderRequestData,
+};
+
+/// HTTP transport that serializes params as a positional array and tolerates
+/// id-less error bodies. Required for gateways (e.g. Infura) that only accept
+/// by-position JSON-RPC params and omit `id` on bad-request errors.
+#[derive(Debug, Clone)]
+pub struct PositionalHttpTransport {
+    client: Client,
+    url: Url,
+}
+
+impl PositionalHttpTransport {
+    pub fn new(url: impl Into<Url>) -> Self {
+        Self {
+            client: Client::new(),
+            url: url.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PositionalRequest {
+    id: u64,
+    jsonrpc: &'static str,
+    method: JsonRpcMethod,
+    params: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum LooseResponse<T> {
+    Success {
+        #[serde(default)]
+        id: Option<u64>,
+        result: T,
+    },
+    Error {
+        #[serde(default)]
+        id: Option<u64>,
+        error: LooseError,
+    },
+}
+
+#[derive(Deserialize)]
+struct LooseError {
+    code: i64,
+    message: String,
+    #[serde(default)]
+    data: Option<Value>,
+}
+
+// Normalize params to a positional array.
+// - Arrays pass through (some requests, e.g. BlockNumberRequest, already serialize positionally).
+// - Objects are flipped values-only (for single-named-parameter methods used here).
+// - Null becomes `[]` (no-argument methods).
+// - Any other scalar is wrapped in a 1-element array.
+//
+// Multi-field by-name params would alphabetize via serde_json::Map — not a concern
+// for the methods used by this bridge client (at most one named parameter).
+fn to_positional<P: Serialize>(params: P) -> Result<Value, serde_json::Error> {
+    match serde_json::to_value(params)? {
+        Value::Array(a) => Ok(Value::Array(a)),
+        Value::Object(map) => Ok(Value::Array(map.into_values().collect())),
+        Value::Null => Ok(Value::Array(vec![])),
+        other => Ok(Value::Array(vec![other])),
+    }
+}
+
+#[async_trait]
+impl JsonRpcTransport for PositionalHttpTransport {
+    type Error = HttpTransportError;
+
+    async fn send_request<P, R>(
+        &self,
+        method: JsonRpcMethod,
+        params: P,
+    ) -> Result<JsonRpcResponse<R>, Self::Error>
+    where
+        P: Serialize + Send + Sync,
+        R: DeserializeOwned + Send,
+    {
+        let params = to_positional(params).map_err(HttpTransportError::Json)?;
+        let body = serde_json::to_string(&PositionalRequest {
+            id: 1,
+            jsonrpc: "2.0",
+            method,
+            params,
+        })
+        .map_err(HttpTransportError::Json)?;
+
+        tracing::trace!("Sending request via JSON-RPC (positional): {body}");
+
+        let text = self
+            .client
+            .post(self.url.clone())
+            .header("Content-Type", "application/json")
+            .body(body)
+            .send()
+            .await
+            .map_err(HttpTransportError::Reqwest)?
+            .text()
+            .await
+            .map_err(HttpTransportError::Reqwest)?;
+
+        tracing::trace!("Response from JSON-RPC: {text}");
+
+        let loose: LooseResponse<R> =
+            serde_json::from_str(&text).map_err(HttpTransportError::Json)?;
+
+        Ok(match loose {
+            LooseResponse::Success { id, result } => JsonRpcResponse::Success {
+                id: id.unwrap_or(1),
+                result,
+            },
+            LooseResponse::Error { id, error } => JsonRpcResponse::Error {
+                id: id.unwrap_or(1),
+                error: JsonRpcError {
+                    code: error.code,
+                    message: error.message,
+                    data: error.data,
+                },
+            },
+        })
+    }
+
+    async fn send_requests<R>(
+        &self,
+        _requests: R,
+    ) -> Result<Vec<JsonRpcResponse<Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        unimplemented!("batch JSON-RPC is not used by the starknet bridge client")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starknet::{
+        core::types::{BlockId, BlockTag, Felt, FunctionCall},
+        macros::selector,
+        providers::{JsonRpcClient, Provider},
+    };
+
+    const PUBLIC_RPC: &str = "https://starknet-rpc.publicnode.com";
+
+    // STRK fee token on Starknet mainnet — a stable well-known contract.
+    const STRK_TOKEN: Felt = Felt::from_hex_unchecked(
+        "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+    );
+
+    #[tokio::test]
+    async fn send_request_block_number_against_public_rpc() {
+        let url: Url = PUBLIC_RPC.parse().unwrap();
+        let provider = JsonRpcClient::new(PositionalHttpTransport::new(url));
+
+        // `starknet_call` takes two named params (request, block_id) — exercises
+        // the Object → positional-Array conversion end-to-end, mirroring what
+        // `is_transfer_finalised` does in the bridge client.
+        let result = provider
+            .call(
+                FunctionCall {
+                    contract_address: STRK_TOKEN,
+                    entry_point_selector: selector!("name"),
+                    calldata: vec![],
+                },
+                BlockId::Tag(BlockTag::Latest),
+            )
+            .await
+            .expect("starknet_call failed");
+
+        // ByteArray layout: [num_full_words, ...word_felts, pending_word, pending_len]
+        // For "Starknet Token" (14 bytes): [0, 0x537461726b6e657420546f6b656e, 14]
+        assert_eq!(result.len(), 3, "unexpected result shape: {result:?}");
+        assert_eq!(result[0], Felt::ZERO);
+        assert_eq!(
+            result[1],
+            Felt::from_hex_unchecked("0x537461726b6e657420546f6b656e")
+        );
+        assert_eq!(result[2], Felt::from(14u64));
+    }
+}

--- a/bridge-sdk/bridge-clients/starknet-bridge-client/src/starknet_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/starknet-bridge-client/src/starknet_bridge_client.rs
@@ -8,17 +8,19 @@ use starknet::{
         TransactionReceiptWithBlockInfo,
     },
     macros::selector,
-    providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider},
+    providers::{JsonRpcClient, Provider},
     signers::LocalWallet,
 };
 
 use crate::error::StarknetBridgeClientError;
+use crate::rpc_transport::PositionalHttpTransport;
 use omni_types::near_events::OmniBridgeEvent;
 
 pub use builder::StarknetBridgeClientBuilder;
 
 mod builder;
 pub mod error;
+mod rpc_transport;
 
 /// STRK native token contract address on Starknet.
 const STRK_TOKEN: Felt = Felt::from_hex_unchecked(
@@ -49,11 +51,12 @@ pub struct StarknetEventLog {
     pub log_index: u64,
 }
 
-type StarknetAccount = SingleOwnerAccount<Arc<JsonRpcClient<HttpTransport>>, LocalWallet>;
+type StarknetAccount =
+    SingleOwnerAccount<Arc<JsonRpcClient<PositionalHttpTransport>>, LocalWallet>;
 
 /// Starknet bridge client for the OmniBridge contract.
 pub struct StarknetBridgeClient {
-    pub(crate) provider: Arc<JsonRpcClient<HttpTransport>>,
+    pub(crate) provider: Arc<JsonRpcClient<PositionalHttpTransport>>,
     pub(crate) account: Option<Arc<StarknetAccount>>,
     pub(crate) omni_bridge_address: Option<Felt>,
 }


### PR DESCRIPTION
## Summary

Some Starknet RPC gateways (notably Infura) only accept JSON-RPC params in **positional** (array) form and reject the by-name (object) form that `starknet-rs`'s default `HttpTransport` uses — they also omit the `id` field on bad-request error bodies, which breaks the default transport's strict deserialization.

This PR introduces a `PositionalHttpTransport` that:
- Normalizes outgoing params to a positional array (objects → values-only array, null → `[]`, scalars → `[scalar]`, arrays pass through).
- Tolerates id-less error responses by treating `id` as optional and defaulting to `1`.

Mirrors the fix already landed on `bridge-indexer-rs` in [Near-One/bridge-indexer-rs@5fdc2f0](https://github.com/Near-One/bridge-indexer-rs/commit/5fdc2f0e6c782787eda41a54b2f0eb159b6c7bc2).

## What changed

- **New** [`starknet-bridge-client/src/rpc_transport.rs`](bridge-sdk/bridge-clients/starknet-bridge-client/src/rpc_transport.rs) — `PositionalHttpTransport` implementing `JsonRpcTransport`. `send_requests` (batch JSON-RPC) is left `unimplemented!`; the SDK verified not to use batched requests (direct provider calls are only `get_transaction_receipt` and `call`, and `starknet-accounts` doesn't batch either).
- [`starknet_bridge_client.rs`](bridge-sdk/bridge-clients/starknet-bridge-client/src/starknet_bridge_client.rs) / [`builder.rs`](bridge-sdk/bridge-clients/starknet-bridge-client/src/builder.rs) — swap `JsonRpcClient<HttpTransport>` → `JsonRpcClient<PositionalHttpTransport>` on the provider and `StarknetAccount` type alias, and build the provider with `PositionalHttpTransport::new(url)`.
- [`Cargo.toml`](bridge-sdk/bridge-clients/starknet-bridge-client/Cargo.toml) — add `serde`, `reqwest`, `async-trait` dependencies.

