### PR TITLE
feat: support direct safe-deposit recipients in near-fin-transfer-btc

### DIFF
--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.51"
+version = "0.3.52"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -9,7 +9,8 @@ use alloy::signers::local::PrivateKeySigner;
 use evm_bridge_client::EvmBridgeClientBuilder;
 use light_client::LightClientBuilder;
 use near_bridge_client::{
-    btc::format_max_gas_fee, NearBridgeClientBuilder, TransactionOptions, UTXOChainAccounts,
+    btc::{format_max_gas_fee, DepositMsg, SafeDepositMsg},
+    NearBridgeClientBuilder, TransactionOptions, UTXOChainAccounts,
 };
 use near_primitives::{hash::CryptoHash, types::AccountId};
 use omni_connector::{
@@ -38,6 +39,26 @@ impl From<UTXOChainArg> for ChainKind {
         match value {
             UTXOChainArg::Btc => ChainKind::Btc,
             UTXOChainArg::Zcash => ChainKind::Zcash,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum BtcRecipient {
+    Direct(AccountId),
+    Omni(OmniAddress),
+}
+
+impl FromStr for BtcRecipient {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(':') {
+            OmniAddress::from_str(s).map(Self::Omni)
+        } else {
+            AccountId::from_str(s)
+                .map(Self::Direct)
+                .map_err(|e| e.to_string())
         }
     }
 }
@@ -518,17 +539,31 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         vout: usize,
-        #[clap(short, long, help = "The BTC recipient on NEAR")]
-        recipient_id: OmniAddress,
+        #[clap(
+            short,
+            long,
+            help = "The BTC recipient. With chain prefix (e.g. 'near:foo.near') routes via the Omni Bridge; without prefix (e.g. 'foo.near') makes a direct deposit to that NEAR account"
+        )]
+        recipient_id: BtcRecipient,
         #[clap(long, help = "Refund recipient address (Bitcoin/Zcash)")]
         refund_address: Option<String>,
         #[clap(
             short,
             long,
-            help = "The Omni Bridge Fee in satoshi",
+            help = "The Omni Bridge Fee in satoshi (used only with chain-prefixed recipient)",
             default_value = "0"
         )]
         fee: u128,
+        #[clap(
+            long,
+            help = "Optional msg set as SafeDepositMsg.msg (only valid with direct recipient, i.e. without chain prefix)"
+        )]
+        msg: Option<String>,
+        #[clap(
+            long,
+            help = "Print the call args as JSON without submitting the transaction"
+        )]
+        dry_run: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1267,22 +1302,57 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             recipient_id,
             refund_address,
             fee,
+            msg,
+            dry_run,
             config_cli,
         } => {
-            omni_connector(network, config_cli)
-                .fin_transfer(FinTransferArgs::NearFinTransferBTC {
-                    chain_kind: chain.into(),
-                    btc_tx_hash,
-                    vout,
-                    btc_deposit_args: BtcDepositArgs::OmniDepositArgs {
+            let connector = omni_connector(network, config_cli);
+            let deposit_args = match recipient_id {
+                BtcRecipient::Omni(recipient_id) => {
+                    if msg.is_some() {
+                        panic!("--msg is not supported with chain-prefixed recipient; use a direct NEAR account (e.g. 'foo.near') instead");
+                    }
+                    BtcDepositArgs::OmniDepositArgs {
                         recipient_id,
                         refund_address,
                         fee,
+                    }
+                }
+                BtcRecipient::Direct(account_id) => BtcDepositArgs::DepositMsg {
+                    msg: DepositMsg {
+                        recipient_id: account_id,
+                        post_actions: None,
+                        extra_msg: None,
+                        safe_deposit: msg.map(|msg| SafeDepositMsg { msg }),
+                        refund_address,
                     },
-                    transaction_options: TransactionOptions::default(),
-                })
-                .await
-                .unwrap();
+                },
+            };
+
+            if dry_run {
+                let args = connector
+                    .build_fin_btc_transfer_args(chain.into(), btc_tx_hash, vout, deposit_args)
+                    .await
+                    .unwrap();
+                let method_name = if args.deposit_msg.safe_deposit.is_some() {
+                    "safe_verify_deposit"
+                } else {
+                    "verify_deposit"
+                };
+                println!("method: {method_name}");
+                println!("args: {}", serde_json::to_string_pretty(&args).unwrap());
+            } else {
+                connector
+                    .fin_transfer(FinTransferArgs::NearFinTransferBTC {
+                        chain_kind: chain.into(),
+                        btc_tx_hash,
+                        vout,
+                        btc_deposit_args: deposit_args,
+                        transaction_options: TransactionOptions::default(),
+                    })
+                    .await
+                    .unwrap();
+            }
         }
         OmniConnectorSubCommand::BtcVerifyWithdraw {
             chain,

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -555,14 +555,13 @@ impl OmniConnector {
             .await
     }
 
-    pub async fn near_fin_transfer_btc(
+    pub async fn build_fin_btc_transfer_args(
         &self,
         chain: ChainKind,
         tx_hash: String,
         vout: usize,
         deposit_args: BtcDepositArgs,
-        transaction_options: TransactionOptions,
-    ) -> Result<CryptoHash> {
+    ) -> Result<FinBtcTransferArgs> {
         let utxo_bridge_client = self.utxo_bridge_client(chain)?;
         let near_bridge_client = self.near_bridge_client()?;
 
@@ -605,16 +604,29 @@ impl OmniConnector {
         )
         .await?;
 
-        let args = FinBtcTransferArgs {
+        Ok(FinBtcTransferArgs {
             deposit_msg,
             tx_bytes: proof_data.tx_bytes,
             vout,
             tx_block_blockhash: proof_data.tx_block_blockhash,
             tx_index: proof_data.tx_index,
             merkle_proof: proof_data.merkle_proof,
-        };
+        })
+    }
 
-        near_bridge_client
+    pub async fn near_fin_transfer_btc(
+        &self,
+        chain: ChainKind,
+        tx_hash: String,
+        vout: usize,
+        deposit_args: BtcDepositArgs,
+        transaction_options: TransactionOptions,
+    ) -> Result<CryptoHash> {
+        let args = self
+            .build_fin_btc_transfer_args(chain, tx_hash, vout, deposit_args)
+            .await?;
+
+        self.near_bridge_client()?
             .fin_btc_transfer(chain, args, transaction_options)
             .await
     }


### PR DESCRIPTION
**Title:** `feat: support direct safe-deposit recipients in near-fin-transfer-btc`

**Description:**

Adds a direct-deposit mode and `--dry-run` to `near-fin-transfer-btc`:

- `--recipient-id` without a chain prefix (`foo.near`) builds a `DepositMsg` targeting that NEAR account directly, bypassing the Omni Bridge wrapping. With a prefix (`near:foo.near`) the existing Omni Bridge flow is used.
- `--msg` (only valid in direct mode) is set as `SafeDepositMsg.msg`.
- `--dry-run` prints the resolved method name and the JSON args instead of submitting the transaction.
