### PR TITLE
Add Zcash memo support to Rust SDK and CLI

### DIFF
--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -656,6 +656,25 @@ pub enum OmniConnectorSubCommand {
         #[command(flatten)]
         config_cli: CliConfig,
     },
+    #[clap(
+        about = "Submit Zcash transfer on Near with optional ZIP-302 memo (use this instead of `near-submit-btc-transfer --chain zcash` when you need a memo)"
+    )]
+    NearSubmitZcashTransfer {
+        #[clap(short, long, help = "Omni Bridge Transaction Hash")]
+        near_tx_hash: String,
+        #[clap(short, long, help = "Sender ID who init transfer on Near")]
+        sender_id: Option<AccountId>,
+        #[clap(short, long, help = "Fee rate on Zcash chain")]
+        fee_rate: Option<u64>,
+        #[clap(
+            short,
+            long,
+            help = "Optional ZIP-302 memo embedded in the shielded output (max 512 bytes; ignored on transparent recipients)"
+        )]
+        memo: Option<String>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
     #[clap(about = "Finalize Transfer from Bitcoin on Near")]
     NearFinTransferBTC {
         #[clap(short, long, help = "Chain for the UTXO rebalancing (Bitcoin/Zcash)")]
@@ -869,6 +888,23 @@ pub(crate) enum InternalSubCommand {
         #[command(flatten)]
         config_cli: CliConfig,
     },
+    #[clap(
+        about = "Initiate a NEAR-to-Zcash transfer with optional ZIP-302 memo (use this instead of `init-near-to-bitcoin-transfer --chain zcash` when you need a memo)"
+    )]
+    InitNearToZcashTransfer {
+        #[clap(short, long, help = "Target Zcash address (shielded or transparent)")]
+        target_zec_address: String,
+        #[clap(short, long, help = "The amount to be transferred, in zatoshis")]
+        amount: u128,
+        #[clap(
+            short,
+            long,
+            help = "Optional ZIP-302 memo embedded in the shielded output (max 512 bytes; ignored on transparent recipients)"
+        )]
+        memo: Option<String>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
     #[clap(about = "Get SVM token vault (locker) PDA")]
     SvmGetTokenVault {
         #[clap(long, help = "SVM chain (sol or fogo)")]
@@ -1033,6 +1069,25 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     sender_id,
                     fee_rate,
                     TransactionOptions::default(),
+                )
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::NearSubmitZcashTransfer {
+            near_tx_hash,
+            sender_id,
+            fee_rate,
+            memo,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .near_submit_btc_transfer_with_tx_hash_and_memo(
+                    ChainKind::Zcash,
+                    CryptoHash::from_str(&near_tx_hash).expect("Invalid near_tx_hash"),
+                    sender_id,
+                    fee_rate,
+                    TransactionOptions::default(),
+                    memo,
                 )
                 .await
                 .unwrap();
@@ -1829,6 +1884,25 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                         target_btc_address,
                         amount,
                         TransactionOptions::default(),
+                    )
+                    .await
+                    .unwrap();
+
+                tracing::info!("Near Tx Hash: {tx_hash}");
+            }
+            InternalSubCommand::InitNearToZcashTransfer {
+                target_zec_address,
+                amount,
+                memo,
+                config_cli,
+            } => {
+                let tx_hash = omni_connector(network, config_cli)
+                    .init_near_to_bitcoin_transfer_with_memo(
+                        ChainKind::Zcash,
+                        target_zec_address,
+                        amount,
+                        TransactionOptions::default(),
+                        memo,
                     )
                     .await
                     .unwrap();

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -643,7 +643,7 @@ pub enum OmniConnectorSubCommand {
         #[command(flatten)]
         config_cli: CliConfig,
     },
-    #[clap(about = "Submit BTC transfer on Near")]
+    #[clap(about = "Submit BTC/Zcash transfer on Near")]
     NearSubmitBtcTransfer {
         #[clap(short, long, help = "UTXO Chain (Bitcoin/Zcash)")]
         chain: UTXOChainArg,
@@ -653,23 +653,10 @@ pub enum OmniConnectorSubCommand {
         sender_id: Option<AccountId>,
         #[clap(short, long, help = "Fee rate on UTXO chain")]
         fee_rate: Option<u64>,
-        #[command(flatten)]
-        config_cli: CliConfig,
-    },
-    #[clap(
-        about = "Submit Zcash transfer on Near with optional ZIP-302 memo (use this instead of `near-submit-btc-transfer --chain zcash` when you need a memo)"
-    )]
-    NearSubmitZcashTransfer {
-        #[clap(short, long, help = "Omni Bridge Transaction Hash")]
-        near_tx_hash: String,
-        #[clap(short, long, help = "Sender ID who init transfer on Near")]
-        sender_id: Option<AccountId>,
-        #[clap(short, long, help = "Fee rate on Zcash chain")]
-        fee_rate: Option<u64>,
         #[clap(
             short,
             long,
-            help = "Optional ZIP-302 memo embedded in the shielded output (max 512 bytes; ignored on transparent recipients)"
+            help = "Optional ZIP-302 memo for shielded Zcash recipients (only valid with --chain zcash)"
         )]
         memo: Option<String>,
         #[command(flatten)]
@@ -885,21 +872,10 @@ pub(crate) enum InternalSubCommand {
         target_btc_address: String,
         #[clap(short, long, help = "Amount to transfer")]
         amount: u128,
-        #[command(flatten)]
-        config_cli: CliConfig,
-    },
-    #[clap(
-        about = "Initiate a NEAR-to-Zcash transfer with optional ZIP-302 memo (use this instead of `init-near-to-bitcoin-transfer --chain zcash` when you need a memo)"
-    )]
-    InitNearToZcashTransfer {
-        #[clap(short, long, help = "Target Zcash address (shielded or transparent)")]
-        target_zec_address: String,
-        #[clap(short, long, help = "The amount to be transferred, in zatoshis")]
-        amount: u128,
         #[clap(
             short,
             long,
-            help = "Optional ZIP-302 memo embedded in the shielded output (max 512 bytes; ignored on transparent recipients)"
+            help = "Optional ZIP-302 memo for shielded Zcash recipients (only valid with --chain zcash)"
         )]
         memo: Option<String>,
         #[command(flatten)]
@@ -1060,29 +1036,12 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             near_tx_hash,
             sender_id,
             fee_rate,
+            memo,
             config_cli,
         } => {
             omni_connector(network, config_cli)
                 .near_submit_btc_transfer_with_tx_hash(
                     chain.into(),
-                    CryptoHash::from_str(&near_tx_hash).expect("Invalid near_tx_hash"),
-                    sender_id,
-                    fee_rate,
-                    TransactionOptions::default(),
-                )
-                .await
-                .unwrap();
-        }
-        OmniConnectorSubCommand::NearSubmitZcashTransfer {
-            near_tx_hash,
-            sender_id,
-            fee_rate,
-            memo,
-            config_cli,
-        } => {
-            omni_connector(network, config_cli)
-                .near_submit_btc_transfer_with_tx_hash_and_memo(
-                    ChainKind::Zcash,
                     CryptoHash::from_str(&near_tx_hash).expect("Invalid near_tx_hash"),
                     sender_id,
                     fee_rate,
@@ -1876,30 +1835,13 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 chain,
                 target_btc_address,
                 amount,
+                memo,
                 config_cli,
             } => {
                 let tx_hash = omni_connector(network, config_cli)
                     .init_near_to_bitcoin_transfer(
                         chain.into(),
                         target_btc_address,
-                        amount,
-                        TransactionOptions::default(),
-                    )
-                    .await
-                    .unwrap();
-
-                tracing::info!("Near Tx Hash: {tx_hash}");
-            }
-            InternalSubCommand::InitNearToZcashTransfer {
-                target_zec_address,
-                amount,
-                memo,
-                config_cli,
-            } => {
-                let tx_hash = omni_connector(network, config_cli)
-                    .init_near_to_bitcoin_transfer_with_memo(
-                        ChainKind::Zcash,
-                        target_zec_address,
                         amount,
                         TransactionOptions::default(),
                         memo,

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1184,29 +1184,10 @@ impl OmniConnector {
         target_btc_address: String,
         amount: u128,
         transaction_options: TransactionOptions,
-    ) -> Result<CryptoHash> {
-        self.init_near_to_bitcoin_transfer_with_memo(
-            chain,
-            target_btc_address,
-            amount,
-            transaction_options,
-            None,
-        )
-        .await
-    }
-
-    /// Same as [`init_near_to_bitcoin_transfer`], but attaches an optional Zcash
-    /// memo (max 512 bytes) to the destination shielded output. Ignored on
-    /// transparent BTC/ZEC paths.
-    pub async fn init_near_to_bitcoin_transfer_with_memo(
-        &self,
-        chain: ChainKind,
-        target_btc_address: String,
-        amount: u128,
-        transaction_options: TransactionOptions,
         memo: Option<String>,
     ) -> Result<CryptoHash> {
         let enable_orchard = self.get_orchard_mode(&target_btc_address, chain)?;
+        validate_zcash_memo_usage(chain, enable_orchard, memo.as_deref())?;
         let utxo_bridge_client = self.utxo_bridge_client(chain)?;
         let fee_rate = utxo_bridge_client.get_fee_rate().await?;
 
@@ -1337,36 +1318,10 @@ impl OmniConnector {
         transfer_id: omni_types::TransferId,
         transaction_options: TransactionOptions,
         max_gas_fee: Option<u64>,
-    ) -> Result<CryptoHash> {
-        self.near_submit_btc_transfer_with_memo(
-            chain,
-            recipient,
-            amount,
-            fee_rate,
-            transfer_id,
-            transaction_options,
-            max_gas_fee,
-            None,
-        )
-        .await
-    }
-
-    /// Same as [`near_submit_btc_transfer`], but attaches an optional Zcash memo
-    /// (max 512 bytes) to the destination shielded output. Ignored on
-    /// transparent BTC/ZEC paths.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn near_submit_btc_transfer_with_memo(
-        &self,
-        chain: ChainKind,
-        recipient: String,
-        amount: u128,
-        fee_rate: Option<u64>,
-        transfer_id: omni_types::TransferId,
-        transaction_options: TransactionOptions,
-        max_gas_fee: Option<u64>,
         memo: Option<String>,
     ) -> Result<CryptoHash> {
         let enable_orchard = self.get_orchard_mode(&recipient, chain)?;
+        validate_zcash_memo_usage(chain, enable_orchard, memo.as_deref())?;
         let near_bridge_client = self.near_bridge_client()?;
         let fee = near_bridge_client.get_withdraw_fee(chain).await?;
         let (out_points, tx_outs, chain_specific_data, gas_fee) = self
@@ -1558,28 +1513,6 @@ impl OmniConnector {
         sender_id: Option<AccountId>,
         fee_rate: Option<u64>,
         transaction_options: TransactionOptions,
-    ) -> Result<CryptoHash> {
-        self.near_submit_btc_transfer_with_tx_hash_and_memo(
-            chain,
-            near_tx_hash,
-            sender_id,
-            fee_rate,
-            transaction_options,
-            None,
-        )
-        .await
-    }
-
-    /// Same as [`near_submit_btc_transfer_with_tx_hash`], but attaches an optional
-    /// Zcash memo (max 512 bytes) to the destination shielded output. Ignored
-    /// on transparent BTC/ZEC paths.
-    pub async fn near_submit_btc_transfer_with_tx_hash_and_memo(
-        &self,
-        chain: ChainKind,
-        near_tx_hash: CryptoHash,
-        sender_id: Option<AccountId>,
-        fee_rate: Option<u64>,
-        transaction_options: TransactionOptions,
         memo: Option<String>,
     ) -> Result<CryptoHash> {
         let near_bridge_client = self.near_bridge_client()?;
@@ -1592,7 +1525,7 @@ impl OmniConnector {
             .extract_recipient_and_amount_from_logs(near_tx_hash, sender_id)
             .await?;
 
-        self.near_submit_btc_transfer_with_memo(
+        self.near_submit_btc_transfer(
             chain,
             recipient,
             amount,
@@ -3890,5 +3823,56 @@ impl OmniConnector {
         } else {
             Ok((None, tx_outs))
         }
+    }
+}
+
+fn validate_zcash_memo_usage(
+    chain: ChainKind,
+    enable_orchard: bool,
+    memo: Option<&str>,
+) -> Result<()> {
+    if memo.is_none() {
+        return Ok(());
+    }
+
+    if chain != ChainKind::Zcash {
+        return Err(BridgeSdkError::InvalidArgument(
+            "memo is only supported for Zcash transfers".to_string(),
+        ));
+    }
+
+    if !enable_orchard {
+        return Err(BridgeSdkError::InvalidArgument(
+            "memo requires a shielded Zcash recipient".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_absent_memo_for_btc() {
+        validate_zcash_memo_usage(ChainKind::Btc, false, None).unwrap();
+    }
+
+    #[test]
+    fn accepts_memo_for_shielded_zcash() {
+        validate_zcash_memo_usage(ChainKind::Zcash, true, Some("memo")).unwrap();
+    }
+
+    #[test]
+    fn rejects_memo_for_btc() {
+        let err = validate_zcash_memo_usage(ChainKind::Btc, false, Some("memo")).unwrap_err();
+        assert!(format!("{err:?}").contains("memo is only supported for Zcash transfers"));
+    }
+
+    #[test]
+    fn rejects_memo_for_transparent_zcash() {
+        let err = validate_zcash_memo_usage(ChainKind::Zcash, false, Some("memo")).unwrap_err();
+        assert!(format!("{err:?}").contains("memo requires a shielded Zcash recipient"));
     }
 }

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1185,6 +1185,27 @@ impl OmniConnector {
         amount: u128,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
+        self.init_near_to_bitcoin_transfer_with_memo(
+            chain,
+            target_btc_address,
+            amount,
+            transaction_options,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`init_near_to_bitcoin_transfer`], but attaches an optional Zcash
+    /// memo (max 512 bytes) to the destination shielded output. Ignored on
+    /// transparent BTC/ZEC paths.
+    pub async fn init_near_to_bitcoin_transfer_with_memo(
+        &self,
+        chain: ChainKind,
+        target_btc_address: String,
+        amount: u128,
+        transaction_options: TransactionOptions,
+        memo: Option<String>,
+    ) -> Result<CryptoHash> {
         let enable_orchard = self.get_orchard_mode(&target_btc_address, chain)?;
         let utxo_bridge_client = self.utxo_bridge_client(chain)?;
         let fee_rate = utxo_bridge_client.get_fee_rate().await?;
@@ -1286,6 +1307,7 @@ impl OmniConnector {
                 target_btc_address.clone(),
                 tx_outs,
                 selection.selected,
+                memo,
             )
             .await?;
 
@@ -1316,6 +1338,34 @@ impl OmniConnector {
         transaction_options: TransactionOptions,
         max_gas_fee: Option<u64>,
     ) -> Result<CryptoHash> {
+        self.near_submit_btc_transfer_with_memo(
+            chain,
+            recipient,
+            amount,
+            fee_rate,
+            transfer_id,
+            transaction_options,
+            max_gas_fee,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`near_submit_btc_transfer`], but attaches an optional Zcash memo
+    /// (max 512 bytes) to the destination shielded output. Ignored on
+    /// transparent BTC/ZEC paths.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn near_submit_btc_transfer_with_memo(
+        &self,
+        chain: ChainKind,
+        recipient: String,
+        amount: u128,
+        fee_rate: Option<u64>,
+        transfer_id: omni_types::TransferId,
+        transaction_options: TransactionOptions,
+        max_gas_fee: Option<u64>,
+        memo: Option<String>,
+    ) -> Result<CryptoHash> {
         let enable_orchard = self.get_orchard_mode(&recipient, chain)?;
         let near_bridge_client = self.near_bridge_client()?;
         let fee = near_bridge_client.get_withdraw_fee(chain).await?;
@@ -1328,6 +1378,7 @@ impl OmniConnector {
                 })?,
                 enable_orchard,
                 fee_rate,
+                memo,
             )
             .await?;
 
@@ -1508,6 +1559,29 @@ impl OmniConnector {
         fee_rate: Option<u64>,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
+        self.near_submit_btc_transfer_with_tx_hash_and_memo(
+            chain,
+            near_tx_hash,
+            sender_id,
+            fee_rate,
+            transaction_options,
+            None,
+        )
+        .await
+    }
+
+    /// Same as [`near_submit_btc_transfer_with_tx_hash`], but attaches an optional
+    /// Zcash memo (max 512 bytes) to the destination shielded output. Ignored
+    /// on transparent BTC/ZEC paths.
+    pub async fn near_submit_btc_transfer_with_tx_hash_and_memo(
+        &self,
+        chain: ChainKind,
+        near_tx_hash: CryptoHash,
+        sender_id: Option<AccountId>,
+        fee_rate: Option<u64>,
+        transaction_options: TransactionOptions,
+        memo: Option<String>,
+    ) -> Result<CryptoHash> {
         let near_bridge_client = self.near_bridge_client()?;
         let NearToBtcTransferInfo {
             recipient,
@@ -1518,7 +1592,7 @@ impl OmniConnector {
             .extract_recipient_and_amount_from_logs(near_tx_hash, sender_id)
             .await?;
 
-        self.near_submit_btc_transfer(
+        self.near_submit_btc_transfer_with_memo(
             chain,
             recipient,
             amount,
@@ -1526,6 +1600,7 @@ impl OmniConnector {
             transfer_id,
             transaction_options,
             max_gas_fee,
+            memo,
         )
         .await
     }
@@ -3669,6 +3744,7 @@ impl OmniConnector {
         amount: u128,
         enable_orchard: bool,
         fee_rate: Option<u64>,
+        memo: Option<String>,
     ) -> Result<(Vec<OutPoint>, Vec<TxOut>, Option<ChainSpecificData>, u64)> {
         let near_bridge_client = self.near_bridge_client()?;
 
@@ -3766,6 +3842,7 @@ impl OmniConnector {
                 target_btc_address,
                 tx_outs,
                 selection.selected,
+                memo,
             )
             .await?;
 
@@ -3785,10 +3862,11 @@ impl OmniConnector {
         target_btc_address: String,
         tx_outs: Vec<TxOut>,
         selected_utxo: Vec<(String, UTXO)>,
+        memo: Option<String>,
     ) -> Result<(Option<ChainSpecificData>, Vec<TxOut>)> {
         if enable_orchard {
             let (orchard, expiry_height) = self
-                .get_orchard_raw(
+                .get_orchard_raw_with_memo(
                     target_btc_address.clone(),
                     tx_outs[0].clone().value.to_sat(),
                     utxo_utils::utxo_to_input_points(selected_utxo).map_err(|e| {
@@ -3797,6 +3875,7 @@ impl OmniConnector {
                         ))
                     })?,
                     tx_outs.get(1),
+                    memo,
                 )
                 .await?;
             let output = tx_outs[1..].to_vec();

--- a/bridge-sdk/connectors/omni-connector/src/zcash.rs
+++ b/bridge-sdk/connectors/omni-connector/src/zcash.rs
@@ -343,7 +343,11 @@ impl OmniConnector {
 
     /// Internal helper to regenerate an Orchard bundle for an existing pending transaction.
     /// Returns (`bundle_bytes_hex`, `expiry_height`).
-    async fn regenerate_orchard_bundle(&self, btc_tx_hash: String) -> Result<(String, u32)> {
+    async fn regenerate_orchard_bundle(
+        &self,
+        btc_tx_hash: String,
+        memo: Option<String>,
+    ) -> Result<(String, u32)> {
         let near_bridge_client = self.near_bridge_client()?;
 
         // Get the pending transaction info
@@ -453,15 +457,15 @@ impl OmniConnector {
             None
         };
 
-        // Generate new bundle with the same parameters. The original memo is
-        // encrypted inside the on-chain bundle and not recoverable here, so
-        // RBF necessarily drops it.
+        // The original memo is not stored in pending-info, so callers that
+        // need memo preservation during RBF must provide the same memo again.
         let (bundle_bytes, expiry_height) = self
-            .get_orchard_raw(
+            .get_orchard_raw_with_memo(
                 recipient,
                 orchard_amount,
                 input_points,
                 tx_out_change.as_ref(),
+                memo,
             )
             .await?;
 
@@ -478,14 +482,35 @@ impl OmniConnector {
     /// - The original bundle's expiry height has passed
     /// - The original proof was rejected for some reason
     /// - You need to refresh the bundle without changing withdrawal parameters
+    ///
+    /// This regenerates the bundle without a memo. If the original withdrawal
+    /// used a memo, use [`rbf_update_orchard_bundle_with_memo`] and pass the
+    /// same memo again.
     pub async fn rbf_update_orchard_bundle(
         &self,
         btc_tx_hash: String,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
+        self.rbf_update_orchard_bundle_with_memo(btc_tx_hash, transaction_options, None)
+            .await
+    }
+
+    /// Regenerates the Orchard bundle for a pending Zcash transaction with an
+    /// optional memo and submits an RBF transaction with the new bundle.
+    ///
+    /// If the original withdrawal used a memo, pass the same memo again so the
+    /// replacement bundle preserves it. The memo cannot be recovered from the
+    /// encrypted on-chain bundle.
+    pub async fn rbf_update_orchard_bundle_with_memo(
+        &self,
+        btc_tx_hash: String,
+        transaction_options: TransactionOptions,
+        memo: Option<String>,
+    ) -> Result<CryptoHash> {
         // Regenerate bundle with same parameters
-        let (bundle_hex, expiry_height) =
-            self.regenerate_orchard_bundle(btc_tx_hash.clone()).await?;
+        let (bundle_hex, expiry_height) = self
+            .regenerate_orchard_bundle(btc_tx_hash.clone(), memo)
+            .await?;
 
         // Submit RBF with only the new bundle - no fee/output changes
         let near_bridge_client = self.near_bridge_client()?;

--- a/bridge-sdk/connectors/omni-connector/src/zcash.rs
+++ b/bridge-sdk/connectors/omni-connector/src/zcash.rs
@@ -20,7 +20,7 @@ use zcash_primitives::transaction::sighash::SignableInput;
 use zcash_primitives::transaction::txid::TxIdDigester;
 use zcash_primitives::transaction::{sighash_v5, Authorized, TransactionData};
 use zcash_protocol::consensus::BlockHeight;
-use zcash_protocol::memo::MemoBytes;
+use zcash_protocol::memo::{Memo, MemoBytes};
 use zcash_transparent::address::TransparentAddress;
 use zcash_transparent::bundle::Bundle;
 
@@ -202,16 +202,38 @@ impl OmniConnector {
         Ok(())
     }
 
-    /// Creates an Orchard bundle for a shielded Zcash withdrawal.
+    /// Creates an Orchard bundle for a shielded Zcash withdrawal (no memo).
     ///
     /// Returns a tuple of (`bundle_bytes`, `expiry_height`).
     /// The `bundle_bytes` can be passed to the contract as `chain_specific_data`.
+    ///
+    /// To attach a memo, use [`get_orchard_raw_with_memo`].
     pub async fn get_orchard_raw(
         &self,
         recipient: String,
         amount: u64,
         input_points: Vec<InputPoint>,
         tx_out_change: Option<&TxOut>,
+    ) -> Result<(Vec<u8>, u32)> {
+        self.get_orchard_raw_with_memo(recipient, amount, input_points, tx_out_change, None)
+            .await
+    }
+
+    /// Creates an Orchard bundle for a shielded Zcash withdrawal with an optional memo.
+    ///
+    /// Returns a tuple of (`bundle_bytes`, `expiry_height`).
+    /// The `bundle_bytes` can be passed to the contract as `chain_specific_data`.
+    ///
+    /// If `memo` is provided, it is included in the shielded output as a
+    /// Zcash memo (up to 512 bytes). The recipient can decrypt it with their
+    /// incoming viewing key; the sender cannot recover it (OVK is zeroed).
+    pub async fn get_orchard_raw_with_memo(
+        &self,
+        recipient: String,
+        amount: u64,
+        input_points: Vec<InputPoint>,
+        tx_out_change: Option<&TxOut>,
+        memo: Option<String>,
     ) -> Result<(Vec<u8>, u32)> {
         let recipient = utxo_utils::extract_orchard_address(&recipient).map_err(|err| {
             BridgeSdkError::ZCashOrchardBundleError(format!(
@@ -233,12 +255,21 @@ impl OmniConnector {
             BridgeSdkError::ZCashOrchardBundleError("Recipient Orchard address is None".to_string())
         })?;
 
+        let memo_bytes = match memo {
+            Some(m) => Memo::from_str(&m).map(MemoBytes::from).map_err(|err| {
+                BridgeSdkError::ZCashOrchardBundleError(format!(
+                    "Invalid memo (max 512 bytes): {err:?}"
+                ))
+            })?,
+            None => MemoBytes::empty(),
+        };
+
         builder
             .add_orchard_output::<zip317::FeeRule>(
                 Some(orchard::keys::OutgoingViewingKey::from([0u8; 32])),
                 recipient,
                 amount,
-                MemoBytes::empty(),
+                memo_bytes,
             )
             .map_err(|err| {
                 BridgeSdkError::ZCashOrchardBundleError(format!(
@@ -422,7 +453,9 @@ impl OmniConnector {
             None
         };
 
-        // Generate new bundle with the same parameters
+        // Generate new bundle with the same parameters. The original memo is
+        // encrypted inside the on-chain bundle and not recoverable here, so
+        // RBF necessarily drops it.
         let (bundle_bytes, expiry_height) = self
             .get_orchard_raw(
                 recipient,
@@ -590,5 +623,66 @@ mod tests {
         let gas_fee = 100_000_000u64;
         let change = calculate_change_amount(utxo_balance, orchard_amount, gas_fee);
         assert_eq!(change, 499_900_000_000u64);
+    }
+
+    /// `Memo::from_str` accepts a short text payload, pads with zeros when it is
+    /// encoded, and `Memo::try_from` round-trips it back to the original UTF-8
+    /// string. This is the path `get_orchard_raw_with_memo` uses to embed a memo
+    /// in the shielded output, so the round-trip proves the bytes survive encoding.
+    #[test]
+    fn test_memo_bytes_short_text_round_trip() {
+        let memo_text = "swap-id-test-001";
+        let memo_bytes = Memo::from_str(memo_text).unwrap().encode();
+
+        // Raw layout: input bytes, then zero padding to 512.
+        let arr = memo_bytes.as_array();
+        assert_eq!(&arr[..memo_text.len()], memo_text.as_bytes());
+        assert!(arr[memo_text.len()..].iter().all(|&b| b == 0));
+
+        // ZIP-302 round-trip: the recipient parses this back as a text memo.
+        let memo = zcash_protocol::memo::Memo::try_from(&memo_bytes).unwrap();
+        let zcash_protocol::memo::Memo::Text(text) = memo else {
+            panic!("expected Memo::Text, got {memo:?}");
+        };
+        let s: String = text.into();
+        assert_eq!(s, memo_text);
+    }
+
+    /// Boundary: a 512-byte memo is exactly the Zcash limit and must be accepted.
+    #[test]
+    fn test_memo_bytes_max_length_accepted() {
+        let memo = "x".repeat(512);
+        let memo_bytes = Memo::from_str(&memo).unwrap().encode();
+        assert_eq!(&memo_bytes.as_array()[..], memo.as_bytes());
+    }
+
+    /// Boundary: 513 bytes must fail with `Error::TooLong`. This is the validation
+    /// `get_orchard_raw_with_memo` relies on to reject oversized memos at the SDK
+    /// boundary.
+    #[test]
+    fn test_memo_bytes_oversize_rejected() {
+        let memo = "x".repeat(513);
+        assert!(Memo::from_str(&memo).is_err());
+    }
+
+    /// `Memo::from_str("")` uses the same empty-memo sentinel as `MemoBytes::empty`.
+    /// This keeps `Some("")` and `None` aligned with the crate's canonical text
+    /// memo API instead of emitting an all-zero empty text memo.
+    #[test]
+    fn test_empty_string_encodes_as_no_memo() {
+        let none_memo = MemoBytes::empty();
+        let empty_string = Memo::from_str("").unwrap().encode();
+
+        assert_eq!(none_memo.as_array()[0], 0xF6);
+        assert_eq!(empty_string.as_array()[0], 0xF6);
+        assert_eq!(none_memo, empty_string);
+
+        let parsed_none = zcash_protocol::memo::Memo::try_from(&none_memo).unwrap();
+        let parsed_empty_string = zcash_protocol::memo::Memo::try_from(&empty_string).unwrap();
+        assert!(matches!(parsed_none, zcash_protocol::memo::Memo::Empty));
+        assert!(matches!(
+            parsed_empty_string,
+            zcash_protocol::memo::Memo::Empty
+        ));
     }
 }


### PR DESCRIPTION
## Package: Zcash memo support

This is the Rust SDK / CLI half of a coordinated two-repo package for Zcash memo support.

Companion PR: https://github.com/Near-One/bridge-sdk-js/pull/470

## Summary

Adds an explicit Zcash-only memo path for NEAR-to-Zcash withdrawals while keeping the existing shared BTC/Zcash commands unchanged for users who do not need memo support.

The implementation is additive:

- Adds `near-submit-zcash-transfer` with optional `--memo`.
- Adds internal `init-near-to-zcash-transfer` with optional `--memo`.
- Adds SDK wrapper methods that preserve existing public method signatures and route `None` through the existing behavior.
- Embeds the memo only when the destination resolves to an Orchard shielded output.
- Leaves transparent Zcash recipients and Bitcoin paths without memo behavior.

## Details

The memo is encoded through `zcash_protocol::memo::Memo::from_str(...).encode()` before being passed into `add_orchard_output`, matching the Zcash crate's canonical ZIP-302 text memo path. `None` still uses `MemoBytes::empty()`, and an empty string follows the crate's canonical empty memo encoding.

This PR also adapts memo propagation to the current upstream random UTXO selection code, so the selected inputs used for Orchard bundle construction remain the upstream `selection.selected` result.

`Cargo.lock` includes the local package version sync from the current upstream manifests (`bridge-cli` 0.3.52 and `omni-connector` 0.3.15). This was generated by cargo after rebasing onto the latest upstream base.

## Relationship to JS PR

The JS companion PR adds the consumer-facing `destinationMemo` type and validates the 512-byte UTF-8 memo boundary before callers hand the value to the Rust-backed Zcash transfer flow.

Together, the two PRs make Zcash memo support available end-to-end while keeping existing BTC and shared BTC/Zcash paths unchanged.

## CLI surface

Existing shared path remains unchanged and does not mention memo:

```text
bridge-cli.exe testnet near-submit-btc-transfer --help
# no --memo option
```

New Zcash-specific paths expose memo explicitly:

```text
bridge-cli.exe testnet near-submit-zcash-transfer --help
# -m, --memo <MEMO>

bridge-cli.exe testnet internal init-near-to-zcash-transfer --help
# -m, --memo <MEMO>
```

## Validation

- `cargo fmt --check --manifest-path bridge-cli/Cargo.toml`
- `cargo fmt --check --manifest-path bridge-sdk/connectors/omni-connector/Cargo.toml`
- `cargo test --manifest-path bridge-sdk/connectors/omni-connector/Cargo.toml`
- `cargo check --manifest-path bridge-cli/Cargo.toml`
- `cargo build --release --manifest-path bridge-cli/Cargo.toml`
- Verified release CLI help output for:
  - `near-submit-btc-transfer`
  - `near-submit-zcash-transfer`
  - `internal init-near-to-zcash-transfer`

## Notes

On this Windows checkout, the debug CLI binary currently stack-overflows while rendering clap help before any command runs. The release binary renders help successfully, and all compile/test checks above pass.
