### PR TITLE
feat: expose pending-info state on BTCPendingInfoPartial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.51"
+version = "0.3.53"
 dependencies = [
  "alloy",
  "clap",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.14"
+version = "0.3.16"
 dependencies = [
  "alloy",
  "bip0039",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.52"
+version = "0.3.53"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -52,6 +52,43 @@ pub enum VUTXO {
 
 #[serde_as]
 #[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub struct OriginalState {
+    pub stage: PendingInfoStage,
+    #[serde_as(as = "DisplayFromStr")]
+    pub max_gas_fee: u128,
+    pub last_rbf_time_sec: Option<u32>,
+    pub cancel_rbf_reserved: Option<U128>,
+}
+
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub enum PendingInfoStage {
+    PendingSign,
+    PendingVerify,
+    PendingBurn,
+}
+
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub struct RbfState {
+    pub stage: PendingInfoStage,
+    pub original_tx_id: String,
+}
+
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
+pub enum PendingInfoState {
+    WithdrawOriginal(OriginalState),
+    WithdrawUserRbf(RbfState),
+    WithdrawCancelRbf(RbfState),
+    ActiveUtxoManagementOriginal(OriginalState),
+    ActiveUtxoManagementRbf(RbfState),
+    ActiveUtxoManagementCancelRbf(RbfState),
+    Refund(OriginalState),
+}
+
+#[serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub struct BTCPendingInfoPartial {
     pub account_id: AccountId,
     pub btc_pending_id: String,
@@ -67,6 +104,7 @@ pub struct BTCPendingInfoPartial {
     pub burn_amount: u128,
     pub tx_bytes_with_sign: Option<Vec<u8>>,
     pub vutxos: Vec<VUTXO>,
+    pub state: PendingInfoState,
 }
 
 #[serde_as]

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2021"
 rust-version = "1.88.0"
 


### PR DESCRIPTION
## Summary
- Adds `state: PendingInfoState` to `BTCPendingInfoPartial`, plus supporting types (`PendingInfoStage`, `OriginalState`, `RbfState`, `PendingInfoState`) mirroring the BTC connector contract.
- Lets callers distinguish withdraw / active-UTXO-management / refund flows, original vs. user-RBF vs. cancel-RBF variants, and the current stage (PendingSign / PendingVerify / PendingBurn).
- Bumps `bridge-cli` to 0.3.53 and `omni-connector` to 0.3.16.

## Test plan
- [ ] `cargo build --locked`
- [ ] `cargo clippy --locked`
- [ ] Fetch a real pending info via `bridge-cli` and confirm the new `state` field deserializes for each variant (withdraw original, RBF, cancel-RBF; active-UTXO-management original, RBF, cancel-RBF; refund).

🤖 Generated with [Claude Code](https://claude.com/claude-code)