### PR TITLE
Proactive UTXO consolidation in withdraw selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 dependencies = [
  "alloy",
  "clap",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "alloy",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.51"
+version = "0.3.53"
 dependencies = [
  "alloy",
  "clap",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.14"
+version = "0.3.16"
 dependencies = [
  "alloy",
  "bip0039",
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitcoin",
  "k256",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.52"
+version = "0.3.53"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -912,6 +912,7 @@ impl NearBridgeClient {
             max_change_number: config.max_change_number.into(),
             passive_management_lower_limit: config.passive_management_lower_limit,
             passive_management_upper_limit: config.passive_management_upper_limit,
+            active_management_upper_limit: config.active_management_upper_limit,
         })
     }
 

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -467,10 +467,13 @@ fn split_into_n_pieces(
 /// Pool-size zones (relative to `pool_size = utxos.len()`):
 /// - Healthy (`pool_size <= active_upper`): normal selection.
 /// - Early-merge (`active_upper < pool_size <= passive_upper`): proactively
-///   filter out UTXOs with `balance > net_amount` to favor consolidation. If
-///   that filter leaves the pool unable to produce a valid selection, fall
-///   back to a normal unfiltered selection — the contract still allows
-///   `input_num <= change_num` here.
+///   filter out UTXOs with `balance > net_amount` to favor consolidation. Two
+///   fallbacks to an unfiltered selection apply in this zone (contract still
+///   allows `input_num <= change_num` here):
+///   * the filter leaves the pool unable to produce a valid selection;
+///   * the filtered selection ends up with more than `baseline_n + 1` inputs,
+///     where `baseline_n` is the unfiltered greedy minimum — i.e. consolidation
+///     would be disproportionately expensive for a single withdraw.
 /// - HIGH (`pool_size > passive_upper`): same filter, but no fallback —
 ///   the contract requires `input_num > change_num`.
 ///
@@ -507,8 +510,30 @@ pub fn choose_utxos_random<R: rand::Rng>(
             .filter(|(_, u)| u128::from(u.balance) <= net_amount)
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+
         match select_and_finalize(target, net_amount, filtered, pool_size, params, rng) {
-            Ok(selection) => return Ok(selection),
+            Ok(selection) => {
+                if in_high_zone {
+                    // HIGH zone: contract forbids `input_num <= change_num`, so
+                    // we have no fallback — return whatever merge produced.
+                    return Ok(selection);
+                }
+                // Early-merge zone: cap how aggressive consolidation may be.
+                // If merge inflates input count by more than 1 over the
+                // unfiltered greedy baseline, prefer the baseline and let
+                // active management handle consolidation separately.
+                let baseline_n =
+                    determine_optimal_n(target, &utxos, params.max_withdrawal_input_number)
+                        .ok();
+                let too_fat = matches!(
+                    baseline_n,
+                    Some(n) if selection.selected.len() > n + 1
+                );
+                if !too_fat {
+                    return Ok(selection);
+                }
+                // Too fat: fall through to unfiltered selection.
+            }
             Err(e) if in_high_zone => return Err(e),
             Err(_) => {
                 // Early-merge zone: fall through to unfiltered selection.

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -200,6 +200,11 @@ pub struct WithdrawSelectionParams {
     pub max_change_number: usize,
     pub passive_management_lower_limit: u32,
     pub passive_management_upper_limit: u32,
+    /// Pool size above which we proactively switch withdraws into merge mode
+    /// (drop UTXOs with `balance > net_amount`) to consolidate the pool before
+    /// it reaches `passive_management_upper_limit`. Mirrors the contract
+    /// parameter of the same name.
+    pub active_management_upper_limit: u32,
 }
 
 /// Splits `change` into `n` outputs each strictly less than `max_per_piece`
@@ -459,13 +464,19 @@ fn split_into_n_pieces(
 /// Picks UTXOs to cover `net_amount` such that the resulting change is at least
 /// `min_change_amount` (avoiding the dust-zone where change ∈ (0, min_change_amount)).
 ///
-/// Algorithm:
-/// 0. If `pool_size > passive_management_upper_limit` (HIGH zone), filter out UTXOs
-///    with `balance > net_amount`. This forces multi-input or 1-input absorption,
-///    both of which trivially satisfy `input_num > change_num` (the HIGH zone rule).
-///    Single-input + 1-change is impossible after this filter.
-/// 1. Greedy largest-first determines the minimum number of inputs N
-///    needed to cover `net_amount + min_change_amount`.
+/// Pool-size zones (relative to `pool_size = utxos.len()`):
+/// - Healthy (`pool_size <= active_upper`): normal selection.
+/// - Early-merge (`active_upper < pool_size <= passive_upper`): proactively
+///   filter out UTXOs with `balance > net_amount` to favor consolidation. If
+///   that filter leaves the pool unable to produce a valid selection, fall
+///   back to a normal unfiltered selection — the contract still allows
+///   `input_num <= change_num` here.
+/// - HIGH (`pool_size > passive_upper`): same filter, but no fallback —
+///   the contract requires `input_num > change_num`.
+///
+/// Algorithm (per attempt):
+/// 1. Greedy largest-first determines the minimum number of inputs N needed
+///    to cover `net_amount + min_change_amount`.
 /// 2. Randomized iterative pick: at each step, the candidate pool is UTXOs
 ///    with `balance >= remaining / n_remaining` (compared via multiplication
 ///    to avoid integer-division loss). One candidate is picked uniformly at random.
@@ -487,17 +498,36 @@ pub fn choose_utxos_random<R: rand::Rng>(
         .checked_add(params.min_change_amount)
         .ok_or_else(|| "target overflow".to_string())?;
 
-    // HIGH zone: drop UTXOs that alone would push us into single-input territory.
-    // We keep UTXOs with balance <= net_amount (absorption-friendly threshold).
-    let utxos = if pool_size > params.passive_management_upper_limit {
-        utxos
-            .into_iter()
-            .filter(|(_, u)| u128::from(u.balance) <= net_amount)
-            .collect()
-    } else {
-        utxos
-    };
+    let in_high_zone = pool_size > params.passive_management_upper_limit;
+    let in_merge_zone = pool_size > params.active_management_upper_limit;
 
+    if in_merge_zone {
+        let filtered: HashMap<String, UTXO> = utxos
+            .iter()
+            .filter(|(_, u)| u128::from(u.balance) <= net_amount)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        match select_and_finalize(target, net_amount, filtered, pool_size, params, rng) {
+            Ok(selection) => return Ok(selection),
+            Err(e) if in_high_zone => return Err(e),
+            Err(_) => {
+                // Early-merge zone: fall through to unfiltered selection.
+                // Contract permits `input_num <= change_num` below passive_upper.
+            }
+        }
+    }
+
+    select_and_finalize(target, net_amount, utxos, pool_size, params, rng)
+}
+
+fn select_and_finalize<R: rand::Rng>(
+    target: u128,
+    net_amount: u128,
+    utxos: HashMap<String, UTXO>,
+    pool_size: u32,
+    params: &WithdrawSelectionParams,
+    rng: &mut R,
+) -> Result<UtxoSelection, String> {
     let n = determine_optimal_n(target, &utxos, params.max_withdrawal_input_number)?;
     let selected = choose_random_iterative(target, n, utxos, rng)?;
     let selection = validate_and_repair(


### PR DESCRIPTION
## Summary
- Trigger the merge filter (`balance <= net_amount`) in `choose_utxos_random` at `active_management_upper_limit`, not only at `passive_management_upper_limit`, so ordinary withdraws consolidate the UTXO pool proactively.
- In the new `(active_upper, passive_upper]` zone, fall back to an unfiltered selection if the filtered pool can't produce a valid combination — the contract still permits `input_num <= change_num` there.
- HIGH zone (`> passive_upper`) behavior unchanged.

## Why
Before, the pool often grew past `passive_upper` while still fragmented; the filter then couldn't find a valid combination and withdraws failed. Consolidating earlier through normal withdraws keeps the pool healthier.