### PR TITLE
fix: zcash-related regressions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+* @Near-One/bridge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 dependencies = [
  "alloy",
  "clap",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "alloy",
  "bip0039",
@@ -11088,7 +11088,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxo-bridge-client"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitcoin",
  "k256",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "bitcoin",
  "k256",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-bridge-client"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/src/types.rs
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/src/types.rs
@@ -18,17 +18,28 @@ pub struct TxProof {
     pub tx_block_blockhash: String,
     pub tx_index: u64,
     pub merkle_proof: Vec<String>,
+    pub outputs: Vec<TxOutputView>,
 }
 
-/// Bundle of work already done for a deposit BTC tx — the network-fetched
-/// `TxProof` together with its parsed `bitcoin::Transaction`. Produced by
+/// Chain-agnostic view of a UTXO transparent output, sufficient for the
+/// fin-transfer / refund / vout-resolution flows. Bitcoin and Zcash have the
+/// same transparent-output shape (a satoshi value plus a `scriptPubKey`) but
+/// incompatible whole-transaction serializations, so carrying these alongside
+/// the proof lets downstream callers consume outputs without re-parsing the
+/// raw tx bytes.
+#[derive(Debug, Clone)]
+pub struct TxOutputView {
+    pub value_sat: u64,
+    pub script_pubkey: Vec<u8>,
+}
+
+/// Bundle of work already done for a deposit BTC tx. Produced by
 /// `resolve_deposit_vout` and threaded into a follow-up
 /// `build_fin_btc_transfer_args` / `btc_request_refund` to skip a second
-/// `extract_btc_proof` round-trip and a second tx-bytes parse.
+/// `extract_btc_proof` round-trip.
 #[derive(Debug)]
 pub struct PrefetchedTxData {
     pub proof: TxProof,
-    pub parsed_tx: bitcoin::Transaction,
 }
 
 pub struct UtxoBridgeTransactionData {

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use std::{marker::PhantomData, str::FromStr};
 
 use crate::error::UtxoClientError;
-use crate::types::{TxProof, UTXOChain, UTXOChainBlock, UtxoBridgeTransactionData};
+use crate::types::{TxOutputView, TxProof, UTXOChain, UTXOChainBlock, UtxoBridgeTransactionData};
 
 pub mod error;
 pub mod types;
@@ -66,19 +66,8 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
         &self,
         tx_hash: &str,
     ) -> Result<BlockHash, UtxoClientError> {
-        let result = self.get_raw_transaction(tx_hash).await?;
-
-        let hash_str = result["blockhash"].as_str().ok_or_else(|| {
-            UtxoClientError::RpcError(format!(
-                "Block hash not found in transaction data. Data: {result}",
-            ))
-        })?;
-
-        let block_hash = BlockHash::from_str(hash_str).map_err(|e| {
-            UtxoClientError::RpcError(format!("Block hash parsing error: {e}. Data: {result}",))
-        })?;
-
-        Ok(block_hash)
+        let raw_tx = self.get_raw_transaction(tx_hash).await?;
+        parse_block_hash(&raw_tx)
     }
 
     pub async fn get_block_height_by_block_hash(
@@ -176,7 +165,9 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
     }
 
     pub async fn extract_btc_proof(&self, tx_hash: &str) -> Result<TxProof, UtxoClientError> {
-        let block_hash = self.get_block_hash_by_tx_hash(tx_hash).await?;
+        let raw_tx = self.get_raw_transaction(tx_hash).await?;
+        let block_hash = parse_block_hash(&raw_tx)?;
+        let outputs = parse_outputs(&raw_tx)?;
         let block_height = self
             .get_block_height_by_block_hash(&block_hash.to_string())
             .await?;
@@ -237,6 +228,7 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
                 .try_into()
                 .expect("Error on convert usize into u64"),
             merkle_proof: merkle_proof_str,
+            outputs,
         })
     }
 
@@ -387,5 +379,145 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
                 "Failed to parse getrawtransaction result: {e}. Response: {response_text}"
             ))
         })
+    }
+}
+
+fn parse_block_hash(raw_tx: &Value) -> Result<BlockHash, UtxoClientError> {
+    let hash_str = raw_tx["blockhash"].as_str().ok_or_else(|| {
+        UtxoClientError::RpcError(format!(
+            "Block hash not found in transaction data. Data: {raw_tx}",
+        ))
+    })?;
+
+    BlockHash::from_str(hash_str).map_err(|e| {
+        UtxoClientError::RpcError(format!("Block hash parsing error: {e}. Data: {raw_tx}",))
+    })
+}
+
+/// Build a chain-agnostic view of a transaction's transparent outputs from
+/// the verbose `getrawtransaction` JSON. Reading from the JSON (rather than
+/// re-deserializing `tx_bytes`) is the only practical path that works for
+/// both Bitcoin and Zcash, whose whole-tx serializations are incompatible.
+fn parse_outputs(raw_tx: &Value) -> Result<Vec<TxOutputView>, UtxoClientError> {
+    let vout = raw_tx["vout"].as_array().ok_or_else(|| {
+        UtxoClientError::RpcError(format!("vout not found in transaction data. Data: {raw_tx}"))
+    })?;
+
+    vout.iter()
+        .enumerate()
+        .map(|(i, out)| {
+            let value_btc = out["value"].as_f64().ok_or_else(|| {
+                UtxoClientError::RpcError(format!(
+                    "vout[{i}] has no value. Transaction data: {raw_tx}"
+                ))
+            })?;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::as_conversions
+            )]
+            let value_sat = (value_btc * SATS_PER_BTC) as u64;
+
+            let script_hex = out["scriptPubKey"]["hex"].as_str().ok_or_else(|| {
+                UtxoClientError::RpcError(format!(
+                    "vout[{i}] missing scriptPubKey.hex. Transaction data: {raw_tx}"
+                ))
+            })?;
+            let script_pubkey = hex::decode(script_hex).map_err(|e| {
+                UtxoClientError::RpcError(format!(
+                    "vout[{i}] has invalid scriptPubKey.hex: {e}. Transaction data: {raw_tx}"
+                ))
+            })?;
+
+            Ok(TxOutputView {
+                value_sat,
+                script_pubkey,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_outputs_bitcoin_style() {
+        // Shape returned by bitcoind getrawtransaction verbose=true.
+        let raw = serde_json::json!({
+            "vout": [
+                {
+                    "value": 0.001,
+                    "n": 0,
+                    "scriptPubKey": {
+                        "hex": "76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac",
+                        "type": "pubkeyhash"
+                    }
+                },
+                {
+                    "value": 0.5,
+                    "n": 1,
+                    "scriptPubKey": {
+                        "hex": "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+                        "type": "witness_v0_keyhash"
+                    }
+                }
+            ]
+        });
+
+        let outs = parse_outputs(&raw).unwrap();
+        assert_eq!(outs.len(), 2);
+        assert_eq!(outs[0].value_sat, 100_000);
+        assert_eq!(
+            outs[0].script_pubkey,
+            hex::decode("76a91489abcdefabbaabbaabbaabbaabbaabbaabbaabba88ac").unwrap()
+        );
+        assert_eq!(outs[1].value_sat, 50_000_000);
+    }
+
+    #[test]
+    fn parse_outputs_zcash_style() {
+        // Shape returned by zcashd / zebrad getrawtransaction verbose=1: same
+        // schema for the transparent vout we care about.
+        let raw = serde_json::json!({
+            "vout": [
+                {
+                    "value": 0.00001,
+                    "n": 0,
+                    "scriptPubKey": {
+                        "hex": "76a914a0b0c0d0e0f000112233445566778899aabbccdd88ac",
+                        "type": "pubkeyhash",
+                        "addresses": ["t1abcdef"]
+                    }
+                }
+            ]
+        });
+
+        let outs = parse_outputs(&raw).unwrap();
+        assert_eq!(outs.len(), 1);
+        assert_eq!(outs[0].value_sat, 1000);
+        assert_eq!(outs[0].script_pubkey.len(), 25);
+    }
+
+    #[test]
+    fn parse_outputs_rejects_missing_vout() {
+        let raw = serde_json::json!({});
+        assert!(parse_outputs(&raw).is_err());
+    }
+
+    #[test]
+    fn parse_outputs_rejects_missing_script_hex() {
+        let raw = serde_json::json!({
+            "vout": [{"value": 0.1, "scriptPubKey": {}}]
+        });
+        assert!(parse_outputs(&raw).is_err());
+    }
+
+    #[test]
+    fn parse_outputs_rejects_invalid_script_hex() {
+        let raw = serde_json::json!({
+            "vout": [{"value": 0.1, "scriptPubKey": {"hex": "not-hex"}}]
+        });
+        assert!(parse_outputs(&raw).is_err());
     }
 }

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
@@ -14,8 +14,6 @@ use crate::types::{TxOutputView, TxProof, UTXOChain, UTXOChainBlock, UtxoBridgeT
 pub mod error;
 pub mod types;
 
-const SATS_PER_BTC: f64 = 100_000_000.0;
-
 pub enum AuthOptions {
     None,
     XApiKey(String),
@@ -145,12 +143,13 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
                 "Amount not found in output. Transaction data: {result}",
             ))
         })?;
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            clippy::as_conversions
-        )]
-        let amount = (amount_btc * SATS_PER_BTC) as u64;
+        let amount = bitcoin::Amount::from_btc(amount_btc)
+            .map_err(|e| {
+                UtxoClientError::RpcError(format!(
+                    "Invalid output value {amount_btc}: {e}. Transaction data: {result}"
+                ))
+            })?
+            .to_sat();
 
         let vout: u32 = output_index.try_into().map_err(|_| {
             UtxoClientError::RpcError(format!("Output index too large: {output_index}"))
@@ -400,7 +399,9 @@ fn parse_block_hash(raw_tx: &Value) -> Result<BlockHash, UtxoClientError> {
 /// both Bitcoin and Zcash, whose whole-tx serializations are incompatible.
 fn parse_outputs(raw_tx: &Value) -> Result<Vec<TxOutputView>, UtxoClientError> {
     let vout = raw_tx["vout"].as_array().ok_or_else(|| {
-        UtxoClientError::RpcError(format!("vout not found in transaction data. Data: {raw_tx}"))
+        UtxoClientError::RpcError(format!(
+            "vout not found in transaction data. Data: {raw_tx}"
+        ))
     })?;
 
     vout.iter()
@@ -411,12 +412,19 @@ fn parse_outputs(raw_tx: &Value) -> Result<Vec<TxOutputView>, UtxoClientError> {
                     "vout[{i}] has no value. Transaction data: {raw_tx}"
                 ))
             })?;
-            #[allow(
-                clippy::cast_possible_truncation,
-                clippy::cast_sign_loss,
-                clippy::as_conversions
-            )]
-            let value_sat = (value_btc * SATS_PER_BTC) as u64;
+            // `bitcoin::Amount::from_btc` does the f64 → sat conversion with
+            // a round-to-nearest step (avoiding the `(0.07 * 1e8) as u64 ==
+            // 6_999_999` off-by-one) and rejects negative / NaN / over-supply
+            // inputs. f64 mantissa precision is still the ceiling — values
+            // with more than ~15 significant decimal digits may still drop a
+            // sat — but BTC/ZEC RPC amounts are well under that bound.
+            let value_sat = bitcoin::Amount::from_btc(value_btc)
+                .map_err(|e| {
+                    UtxoClientError::RpcError(format!(
+                        "vout[{i}] has invalid value {value_btc}: {e}. Transaction data: {raw_tx}"
+                    ))
+                })?
+                .to_sat();
 
             let script_hex = out["scriptPubKey"]["hex"].as_str().ok_or_else(|| {
                 UtxoClientError::RpcError(format!(
@@ -497,6 +505,32 @@ mod tests {
         assert_eq!(outs.len(), 1);
         assert_eq!(outs[0].value_sat, 1000);
         assert_eq!(outs[0].script_pubkey.len(), 25);
+    }
+
+    #[test]
+    fn parse_outputs_handles_float_precision_landmine() {
+        // 0.07_f64 * 1e8 == 6_999_999.999_999_998 in IEEE-754. A naive
+        // `(value * 1e8) as u64` truncates to 6_999_999; `Amount::from_btc`
+        // rounds to nearest and returns 7_000_000.
+        let raw = serde_json::json!({
+            "vout": [{
+                "value": 0.07,
+                "scriptPubKey": {"hex": "00"}
+            }]
+        });
+        let outs = parse_outputs(&raw).unwrap();
+        assert_eq!(outs[0].value_sat, 7_000_000);
+    }
+
+    #[test]
+    fn parse_outputs_rejects_negative_value() {
+        let raw = serde_json::json!({
+            "vout": [{
+                "value": -0.5,
+                "scriptPubKey": {"hex": "00"}
+            }]
+        });
+        assert!(parse_outputs(&raw).is_err());
     }
 
     #[test]

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.16"
+version = "0.3.17"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -578,19 +578,14 @@ impl OmniConnector {
     ) -> Result<FinBtcTransferArgs> {
         let near_bridge_client = self.near_bridge_client()?;
 
-        let PrefetchedTxData {
-            proof: proof_data,
-            parsed_tx: btc_tx,
-        } = match prefetched {
+        let PrefetchedTxData { proof: proof_data } = match prefetched {
             Some(p) => p,
             None => {
                 let proof = self
                     .utxo_bridge_client(chain)?
                     .extract_btc_proof(&tx_hash)
                     .await?;
-                let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
-                    .map_err(BridgeSdkError::InvalidArgument)?;
-                PrefetchedTxData { proof, parsed_tx }
+                PrefetchedTxData { proof }
             }
         };
 
@@ -612,13 +607,13 @@ impl OmniConnector {
                 .get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
-        let deposit_output = btc_tx.output.get(vout).ok_or_else(|| {
+        let deposit_output = proof_data.outputs.get(vout).ok_or_else(|| {
             BridgeSdkError::InvalidArgument(format!(
                 "vout {vout} out of range; tx has {} outputs",
-                btc_tx.output.len()
+                proof_data.outputs.len()
             ))
         })?;
-        let deposit_amount = u128::from(deposit_output.value.to_sat());
+        let deposit_amount = u128::from(deposit_output.value_sat);
 
         // The contract dispatches to `get_extra_msg_confirmations` only when
         // calling `verify_deposit` with `extra_msg` set. `safe_verify_deposit`
@@ -760,29 +755,24 @@ impl OmniConnector {
     ) -> Result<BtcRequestRefundArgs> {
         let near_bridge_client = self.near_bridge_client()?;
 
-        let PrefetchedTxData {
-            proof: proof_data,
-            parsed_tx: btc_tx,
-        } = match prefetched {
+        let PrefetchedTxData { proof: proof_data } = match prefetched {
             Some(p) => p,
             None => {
                 let proof = self
                     .utxo_bridge_client(ChainKind::Btc)?
                     .extract_btc_proof(btc_tx_hash)
                     .await?;
-                let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
-                    .map_err(BridgeSdkError::InvalidArgument)?;
-                PrefetchedTxData { proof, parsed_tx }
+                PrefetchedTxData { proof }
             }
         };
 
-        let deposit_output = btc_tx.output.get(vout).ok_or_else(|| {
+        let deposit_output = proof_data.outputs.get(vout).ok_or_else(|| {
             BridgeSdkError::InvalidArgument(format!(
                 "vout {vout} out of range; tx has {} outputs",
-                btc_tx.output.len()
+                proof_data.outputs.len()
             ))
         })?;
-        let deposit_amount = u128::from(deposit_output.value.to_sat());
+        let deposit_amount = u128::from(deposit_output.value_sat);
 
         self.ensure_sufficient_btc_confirmations(
             ChainKind::Btc,
@@ -987,21 +977,19 @@ impl OmniConnector {
             .extract_btc_proof(tx_hash)
             .await?;
 
-        let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
-            .map_err(BridgeSdkError::InvalidArgument)?;
-
-        let matches: Vec<usize> = parsed_tx
-            .output
+        let expected_script_bytes = expected_script.as_bytes();
+        let matches: Vec<usize> = proof
+            .outputs
             .iter()
             .enumerate()
-            .filter_map(|(i, out)| (out.script_pubkey == expected_script).then_some(i))
+            .filter_map(|(i, out)| (out.script_pubkey == expected_script_bytes).then_some(i))
             .collect();
 
         match matches.as_slice() {
             [] => Err(BridgeSdkError::InvalidArgument(format!(
                 "No output in tx {tx_hash} matches deposit address `{expected_address}`. Verify the recipient/fee/msg match the original deposit."
             ))),
-            [v] => Ok((*v, PrefetchedTxData { proof, parsed_tx })),
+            [v] => Ok((*v, PrefetchedTxData { proof })),
             many => Err(BridgeSdkError::InvalidArgument(format!(
                 "Ambiguous: multiple outputs in tx {tx_hash} match deposit address `{expected_address}`. Re-run with vout set to one of: {many:?}"
             ))),
@@ -1033,18 +1021,16 @@ impl OmniConnector {
             .extract_btc_proof(tx_hash)
             .await?;
 
-        let parsed_tx = utxo_utils::try_bytes_to_btc_transaction(&proof.tx_bytes)
-            .map_err(BridgeSdkError::InvalidArgument)?;
-
         if let Some(v) = prefer_vout {
-            let out = parsed_tx.output.get(v).ok_or_else(|| {
+            let out = proof.outputs.get(v).ok_or_else(|| {
                 BridgeSdkError::InvalidArgument(format!(
                     "vout {v} out of range; tx {tx_hash} has {} outputs",
-                    parsed_tx.output.len()
+                    proof.outputs.len()
                 ))
             })?;
-            let addr = UTXOAddress::from_script(&out.script_pubkey, chain, network)
-                .ok_or_else(|| {
+            let script = bitcoin::Script::from_bytes(&out.script_pubkey);
+            let addr =
+                UTXOAddress::from_script(script, chain, network).ok_or_else(|| {
                     BridgeSdkError::InvalidArgument(format!(
                         "vout {v} in tx {tx_hash} has an unrecognized script_pubkey"
                     ))
@@ -1057,12 +1043,13 @@ impl OmniConnector {
                         "vout {v} in tx {tx_hash} is not a deposit address tracked by the bridge indexer"
                     ))
                 })?;
-            return Ok((v, msg, PrefetchedTxData { proof, parsed_tx }));
+            return Ok((v, msg, PrefetchedTxData { proof }));
         }
 
         let mut found: Option<(usize, DepositMsg)> = None;
-        for (i, out) in parsed_tx.output.iter().enumerate() {
-            let Some(addr) = UTXOAddress::from_script(&out.script_pubkey, chain, network) else {
+        for (i, out) in proof.outputs.iter().enumerate() {
+            let script = bitcoin::Script::from_bytes(&out.script_pubkey);
+            let Some(addr) = UTXOAddress::from_script(script, chain, network) else {
                 continue;
             };
             let Some(msg) = near_bridge_client
@@ -1084,7 +1071,7 @@ impl OmniConnector {
                 "No output in tx {tx_hash} matches a deposit address tracked by the bridge indexer. Pass deposit args explicitly to disambiguate."
             ))
         })?;
-        Ok((vout, msg, PrefetchedTxData { proof, parsed_tx }))
+        Ok((vout, msg, PrefetchedTxData { proof }))
     }
 
     pub async fn active_utxo_management(

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -30,9 +30,9 @@ use omni_types::{
 
 use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
 use near_bridge_client::btc::{
-    BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
-    BtcConfirmationContext, BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg,
-    FinBtcTransferArgs, NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
+    BtcConfirmationContext, BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
+    BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg, FinBtcTransferArgs,
+    NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
 };
 use near_bridge_client::{Decimals, NearBridgeClient, TransactionOptions};
 use solana_bridge_client::{
@@ -603,8 +603,7 @@ impl OmniConnector {
             BtcDepositArgs::NearDirectDepositArgs {
                 recipient_id,
                 refund_address,
-            } => near_bridge_client
-                .get_deposit_msg_for_near_account(recipient_id, refund_address),
+            } => near_bridge_client.get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
         let deposit_output = proof_data.outputs.get(vout).ok_or_else(|| {
@@ -1029,12 +1028,11 @@ impl OmniConnector {
                 ))
             })?;
             let script = bitcoin::Script::from_bytes(&out.script_pubkey);
-            let addr =
-                UTXOAddress::from_script(script, chain, network).ok_or_else(|| {
-                    BridgeSdkError::InvalidArgument(format!(
-                        "vout {v} in tx {tx_hash} has an unrecognized script_pubkey"
-                    ))
-                })?;
+            let addr = UTXOAddress::from_script(script, chain, network).ok_or_else(|| {
+                BridgeSdkError::InvalidArgument(format!(
+                    "vout {v} in tx {tx_hash} has an unrecognized script_pubkey"
+                ))
+            })?;
             let msg = near_bridge_client
                 .get_deposit_msg_by_address(chain, &addr.to_string())
                 .await?

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -725,10 +725,6 @@ pub fn bytes_to_btc_transaction(tx_bytes: &[u8]) -> BtcTransaction {
     deserialize(tx_bytes).expect("Deserialization tx_bytes failed")
 }
 
-pub fn try_bytes_to_btc_transaction(tx_bytes: &[u8]) -> Result<BtcTransaction, String> {
-    deserialize(tx_bytes).map_err(|e| format!("Failed to deserialize BTC tx_bytes: {e}"))
-}
-
 pub fn get_tx_outs_utxo_management(
     change_address: &str,
     output_amount: u64,

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -145,9 +145,7 @@ fn choose_random_iterative<R: rand::Rng>(
         let candidate_indices: Vec<usize> = pool
             .iter()
             .enumerate()
-            .filter(|(_, (_, u))| {
-                u128::from(u.balance).saturating_mul(n_u128) >= remaining
-            })
+            .filter(|(_, (_, u))| u128::from(u.balance).saturating_mul(n_u128) >= remaining)
             .map(|(i, _)| i)
             .collect();
 
@@ -265,10 +263,7 @@ fn validate_and_repair(
             return Err("Selection became empty during repair".to_string());
         }
 
-        let sum: u128 = selected
-            .iter()
-            .map(|(_, u)| u128::from(u.balance))
-            .sum();
+        let sum: u128 = selected.iter().map(|(_, u)| u128::from(u.balance)).sum();
 
         let change = sum
             .checked_sub(net_amount)
@@ -321,8 +316,7 @@ fn validate_and_repair(
             let need_split = num_inputs > 1 && change >= max_change_amount;
 
             let change_amounts = if need_split {
-                let max_per_piece = std::cmp::min(max_change_amount, min_input)
-                    .saturating_sub(1);
+                let max_per_piece = std::cmp::min(max_change_amount, min_input).saturating_sub(1);
                 split_change(change, min_change_amount, max_per_piece, max_change_number)?
             } else {
                 vec![change]
@@ -529,8 +523,7 @@ pub fn choose_utxos_random_no_payment<R: rand::Rng>(
 ) -> Result<UtxoSelection, String> {
     let mut last_user_payment: u128 = 0;
     for _ in 0..MAX_NO_PAYMENT_RETRIES {
-        let selection =
-            choose_utxos_random(net_amount, utxos.clone(), pool_size, params, rng)?;
+        let selection = choose_utxos_random(net_amount, utxos.clone(), pool_size, params, rng)?;
         if selection.user_payment == 0 {
             return Ok(selection);
         }


### PR DESCRIPTION
This pull request introduces a significant refactor to how UTXO transaction outputs are handled in the bridge client and connector code. The main change is to make output parsing chain-agnostic by extracting output data directly from JSON returned by `getrawtransaction`, rather than re-parsing raw transaction bytes. This improves compatibility across Bitcoin and Zcash and simplifies downstream logic. The `TxProof` struct now includes a list of outputs (`outputs`), and all downstream code is updated to consume these outputs instead of parsing transactions again. Several helper functions and tests are added to support this new approach.

Key changes:

**Chain-agnostic output parsing and data flow:**
* Added a new struct `TxOutputView` to represent UTXO outputs in a chain-agnostic way, and included an `outputs` field in `TxProof`. The `extract_btc_proof` method now populates this field by parsing the verbose transaction JSON. [[1]](diffhunk://#diff-fd57664120637bf40c9c29710309fec106454a8545817cf3beb6ea7c54784323R21-L31) [[2]](diffhunk://#diff-30af2e686d3e498b05cb5755f80cac930f1b8d35a5750869e6b2c9543583aa37L179-R170) [[3]](diffhunk://#diff-30af2e686d3e498b05cb5755f80cac930f1b8d35a5750869e6b2c9543583aa37R231)
* Removed all downstream dependencies on parsing raw Bitcoin transactions from bytes; instead, all logic now uses the `outputs` field from `TxProof`. This includes updates to all relevant methods in `OmniConnector`. [[1]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L581-R588) [[2]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L615-R616) [[3]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L763-R775) [[4]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L990-R992) [[5]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L1036-R1033) [[6]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L1060-R1052) [[7]](diffhunk://#diff-ec60012ad46d281928a01c4d1a5f48565e76866e45e8d6f723bf9e4d4abd81b4L1087-R1074)

**Codebase simplification and helper functions:**
* Introduced helper functions `parse_block_hash` and `parse_outputs` to cleanly extract the needed data from transaction JSON. [[1]](diffhunk://#diff-30af2e686d3e498b05cb5755f80cac930f1b8d35a5750869e6b2c9543583aa37L69-R70) [[2]](diffhunk://#diff-30af2e686d3e498b05cb5755f80cac930f1b8d35a5750869e6b2c9543583aa37R384-R523)
* Removed the now-unnecessary `try_bytes_to_btc_transaction` function from `utxo-utils`.

**Testing and validation:**
* Added comprehensive tests for `parse_outputs` to ensure correct parsing for both Bitcoin and Zcash transaction formats, and to handle various edge cases.

**Version bumps:**
* Bumped crate versions for `bridge-cli`, `utxo-bridge-client`, `omni-connector`, and `utxo-utils` to reflect these changes. [[1]](diffhunk://#diff-9a6eceab89766210b0faa115292b58b1f6690a97640a706f3f9e677fe74dc51fL3-R3) [[2]](diffhunk://#diff-0731a8531148101b2f5a485b6d95a2ba364416041929ec44f07276932270e4e0L3-R3) [[3]](diffhunk://#diff-faabcb2648decad4eca1e9202d53b3b25ad467e6a776b1f9835493d0c6f22f85L3-R3) [[4]](diffhunk://#diff-2c45fd6ba2a56d4860f8a4dc308844a78b8a65f634af372c1e8a94fb05406c95L3-R3)

**Repository maintenance:**
* Added a `CODEOWNERS` file assigning ownership to the `@Near-One/bridge` team.