### PR TITLE
feat: allow overriding fee_rate and max input number for active UTXO management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 dependencies = [
  "alloy",
  "clap",
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitcoin",
  "k256",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.53"
+version = "0.3.54"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -788,6 +788,13 @@ pub enum OmniConnectorSubCommand {
     ActiveUTXOManagement {
         #[clap(short, long, help = "Chain for the UTXO rebalancing (Bitcoin/Zcash)")]
         chain: UTXOChainArg,
+        #[clap(short, long, help = "Fee rate on UTXO chain")]
+        fee_rate: Option<u64>,
+        #[clap(
+            long,
+            help = "Override the max number of UTXO inputs to consume in the rebalancing tx (defaults to the value from the bridge config)"
+        )]
+        max_input_number: Option<u8>,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1697,9 +1704,19 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
 
             tracing::info!("BTC Address: {btc_address}");
         }
-        OmniConnectorSubCommand::ActiveUTXOManagement { chain, config_cli } => {
+        OmniConnectorSubCommand::ActiveUTXOManagement {
+            chain,
+            fee_rate,
+            max_input_number,
+            config_cli,
+        } => {
             omni_connector(network, config_cli)
-                .active_utxo_management(chain.into(), TransactionOptions::default())
+                .active_utxo_management(
+                    chain.into(),
+                    fee_rate,
+                    max_input_number,
+                    TransactionOptions::default(),
+                )
                 .await
                 .unwrap();
         }

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -30,9 +30,9 @@ use omni_types::{
 
 use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
 use near_bridge_client::btc::{
-    BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
-    BtcConfirmationContext, BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg,
-    FinBtcTransferArgs, NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
+    BtcConfirmationContext, BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
+    BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg, FinBtcTransferArgs,
+    NearToBtcTransferInfo, TokenReceiverMessage, VUTXO,
 };
 use near_bridge_client::{Decimals, NearBridgeClient, TransactionOptions};
 use solana_bridge_client::{
@@ -608,8 +608,7 @@ impl OmniConnector {
             BtcDepositArgs::NearDirectDepositArgs {
                 recipient_id,
                 refund_address,
-            } => near_bridge_client
-                .get_deposit_msg_for_near_account(recipient_id, refund_address),
+            } => near_bridge_client.get_deposit_msg_for_near_account(recipient_id, refund_address),
         };
 
         let deposit_output = btc_tx.output.get(vout).ok_or_else(|| {
@@ -1043,8 +1042,8 @@ impl OmniConnector {
                     parsed_tx.output.len()
                 ))
             })?;
-            let addr = UTXOAddress::from_script(&out.script_pubkey, chain, network)
-                .ok_or_else(|| {
+            let addr =
+                UTXOAddress::from_script(&out.script_pubkey, chain, network).ok_or_else(|| {
                     BridgeSdkError::InvalidArgument(format!(
                         "vout {v} in tx {tx_hash} has an unrecognized script_pubkey"
                     ))
@@ -1090,10 +1089,15 @@ impl OmniConnector {
     pub async fn active_utxo_management(
         &self,
         chain: ChainKind,
+        fee_rate: Option<u64>,
+        max_input_number: Option<u8>,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
         let utxo_bridge_client = self.utxo_bridge_client(chain)?;
-        let fee_rate = utxo_bridge_client.get_fee_rate().await?;
+        let fee_rate = match fee_rate {
+            Some(rate) => rate,
+            None => utxo_bridge_client.get_fee_rate().await?,
+        };
 
         let near_bridge_client = self.near_bridge_client()?;
 
@@ -1107,6 +1111,8 @@ impl OmniConnector {
             .get_active_management_limit(chain)
             .await?;
 
+        let max_input_number = max_input_number.unwrap_or(max_active_utxo_management_input_number);
+
         let change_address = near_bridge_client.get_change_address(chain).await?;
         let min_deposit_amount = near_bridge_client.get_min_deposit_amount(chain).await?;
 
@@ -1118,7 +1124,7 @@ impl OmniConnector {
                 active_management_lower_limit.try_into().unwrap(),
                 active_management_upper_limit.try_into().unwrap(),
             ),
-            max_active_utxo_management_input_number.into(),
+            max_input_number.into(),
             max_active_utxo_management_output_number.into(),
             min_deposit_amount.try_into().unwrap(),
             chain,

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -145,9 +145,7 @@ fn choose_random_iterative<R: rand::Rng>(
         let candidate_indices: Vec<usize> = pool
             .iter()
             .enumerate()
-            .filter(|(_, (_, u))| {
-                u128::from(u.balance).saturating_mul(n_u128) >= remaining
-            })
+            .filter(|(_, (_, u))| u128::from(u.balance).saturating_mul(n_u128) >= remaining)
             .map(|(i, _)| i)
             .collect();
 
@@ -265,10 +263,7 @@ fn validate_and_repair(
             return Err("Selection became empty during repair".to_string());
         }
 
-        let sum: u128 = selected
-            .iter()
-            .map(|(_, u)| u128::from(u.balance))
-            .sum();
+        let sum: u128 = selected.iter().map(|(_, u)| u128::from(u.balance)).sum();
 
         let change = sum
             .checked_sub(net_amount)
@@ -321,8 +316,7 @@ fn validate_and_repair(
             let need_split = num_inputs > 1 && change >= max_change_amount;
 
             let change_amounts = if need_split {
-                let max_per_piece = std::cmp::min(max_change_amount, min_input)
-                    .saturating_sub(1);
+                let max_per_piece = std::cmp::min(max_change_amount, min_input).saturating_sub(1);
                 split_change(change, min_change_amount, max_per_piece, max_change_number)?
             } else {
                 vec![change]
@@ -529,8 +523,7 @@ pub fn choose_utxos_random_no_payment<R: rand::Rng>(
 ) -> Result<UtxoSelection, String> {
     let mut last_user_payment: u128 = 0;
     for _ in 0..MAX_NO_PAYMENT_RETRIES {
-        let selection =
-            choose_utxos_random(net_amount, utxos.clone(), pool_size, params, rng)?;
+        let selection = choose_utxos_random(net_amount, utxos.clone(), pool_size, params, rng)?;
         if selection.user_payment == 0 {
             return Ok(selection);
         }


### PR DESCRIPTION
## Summary
- Add optional `fee_rate: Option<u64>` and `max_input_number: Option<u8>` parameters to `OmniConnector::active_utxo_management`. When `None`, both fall back to the previous behavior (auto-fetch fee rate via `utxo_bridge_client.get_fee_rate()`, use `max_active_utxo_management_input_number` from the bridge config).
- Wire the two overrides through the `bridge-cli active-utxo-management` subcommand as `--fee-rate` and `--max-input-number` flags.

## Test plan
- [ ] `cargo build` / `cargo clippy` on the workspace
- [ ] Run `bridge-cli active-utxo-management --chain btc` without flags and confirm prior behavior is unchanged
- [ ] Run `bridge-cli active-utxo-management --chain btc --fee-rate <N> --max-input-number <K>` and confirm both overrides are honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)