### PR TITLE
feat(utxo): add --merge-largest flag for active UTXO management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.54"
+version = "0.3.55"
 dependencies = [
  "alloy",
  "clap",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "alloy",
  "bip0039",
@@ -11108,7 +11108,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitcoin",
  "k256",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.54"
+version = "0.3.55"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -795,6 +795,11 @@ pub enum OmniConnectorSubCommand {
             help = "Override the max number of UTXO inputs to consume in the rebalancing tx (defaults to the value from the bridge config)"
         )]
         max_input_number: Option<u8>,
+        #[clap(
+            long,
+            help = "Merge the largest UTXOs instead of the smallest (use ahead of a large withdrawal)"
+        )]
+        merge_largest: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1708,6 +1713,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             chain,
             fee_rate,
             max_input_number,
+            merge_largest,
             config_cli,
         } => {
             omni_connector(network, config_cli)
@@ -1715,6 +1721,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     chain.into(),
                     fee_rate,
                     max_input_number,
+                    merge_largest,
                     TransactionOptions::default(),
                 )
                 .await

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -1091,13 +1091,14 @@ impl NearBridgeClient {
     pub async fn get_active_management_limit(
         &self,
         chain: ChainKind,
-    ) -> Result<(u32, u32, u8, u8)> {
+    ) -> Result<(u32, u32, u8, u8, u128)> {
         let config = self.get_config(chain).await?;
         Ok((
             config.active_management_lower_limit,
             config.active_management_upper_limit,
             config.max_active_utxo_management_input_number,
             config.max_active_utxo_management_output_number,
+            config.max_change_amount,
         ))
     }
 

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1104,26 +1104,8 @@ impl OmniConnector {
         let change_address = near_bridge_client.get_change_address(chain).await?;
         let min_deposit_amount = near_bridge_client.get_min_deposit_amount(chain).await?;
 
-        let mut all_balances: Vec<u64> = utxos.values().map(|u| u.balance).collect();
-        all_balances.sort_unstable_by(|a, b| b.cmp(a));
-        tracing::info!(
-            pool_size = utxos.len(),
-            active_lower = active_management_lower_limit,
-            active_upper = active_management_upper_limit,
-            max_input_num = max_active_utxo_management_input_number,
-            max_output_num = max_active_utxo_management_output_number,
-            min_deposit_amount,
-            max_change_amount,
-            fee_rate,
-            merge_largest,
-            change_address = %change_address,
-            pool_total_balance_sat = all_balances.iter().map(|b| u128::from(*b)).sum::<u128>(),
-            pool_balances_desc = ?all_balances,
-            "Active UTXO management: inputs to selection"
-        );
-
         let (out_points, tx_outs) = utxo_utils::choose_utxos_for_active_management(
-            utxos,
+            utxos.clone(),
             fee_rate,
             &change_address,
             (
@@ -1139,6 +1121,46 @@ impl OmniConnector {
             max_change_amount,
         )
         .map_err(BridgeSdkError::UtxoManagementError)?;
+
+        let inputs_log: Vec<String> = out_points
+            .iter()
+            .map(|op| {
+                let key = format!("{}@{}", op.txid, op.vout);
+                let balance = utxos.get(&key).map(|u| u.balance);
+                match balance {
+                    Some(b) => format!("{key} ({b} sat)"),
+                    None => format!("{key} (?)"),
+                }
+            })
+            .collect();
+        let input_total: u64 = out_points
+            .iter()
+            .filter_map(|op| utxos.get(&format!("{}@{}", op.txid, op.vout)).map(|u| u.balance))
+            .sum();
+
+        let outputs_log: Vec<String> = tx_outs
+            .iter()
+            .map(|o| format!("{} sat", o.value.to_sat()))
+            .collect();
+        let output_total: u64 = tx_outs.iter().map(|o| o.value.to_sat()).sum();
+
+        let gas_fee = input_total.saturating_sub(output_total);
+
+        tracing::debug!(
+            pool_size = utxos.len(),
+            active_lower = active_management_lower_limit,
+            active_upper = active_management_upper_limit,
+            fee_rate,
+            num_inputs = out_points.len(),
+            num_outputs = tx_outs.len(),
+            input_total_sat = input_total,
+            output_total_sat = output_total,
+            gas_fee_sat = gas_fee,
+            inputs = ?inputs_log,
+            outputs = ?outputs_log,
+            change_address = %change_address,
+            "Active UTXO management transaction plan"
+        );
 
         near_bridge_client
             .active_utxo_management(chain, out_points, tx_outs, transaction_options)

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1105,7 +1105,7 @@ impl OmniConnector {
         let min_deposit_amount = near_bridge_client.get_min_deposit_amount(chain).await?;
 
         let (out_points, tx_outs) = utxo_utils::choose_utxos_for_active_management(
-            utxos.clone(),
+            &utxos,
             fee_rate,
             &change_address,
             (

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1077,6 +1077,7 @@ impl OmniConnector {
         chain: ChainKind,
         fee_rate: Option<u64>,
         max_input_number: Option<u8>,
+        merge_largest: bool,
         transaction_options: TransactionOptions,
     ) -> Result<CryptoHash> {
         let utxo_bridge_client = self.utxo_bridge_client(chain)?;
@@ -1093,6 +1094,7 @@ impl OmniConnector {
             active_management_upper_limit,
             max_active_utxo_management_input_number,
             max_active_utxo_management_output_number,
+            max_change_amount,
         ) = near_bridge_client
             .get_active_management_limit(chain)
             .await?;
@@ -1101,6 +1103,24 @@ impl OmniConnector {
 
         let change_address = near_bridge_client.get_change_address(chain).await?;
         let min_deposit_amount = near_bridge_client.get_min_deposit_amount(chain).await?;
+
+        let mut all_balances: Vec<u64> = utxos.values().map(|u| u.balance).collect();
+        all_balances.sort_unstable_by(|a, b| b.cmp(a));
+        tracing::info!(
+            pool_size = utxos.len(),
+            active_lower = active_management_lower_limit,
+            active_upper = active_management_upper_limit,
+            max_input_num = max_active_utxo_management_input_number,
+            max_output_num = max_active_utxo_management_output_number,
+            min_deposit_amount,
+            max_change_amount,
+            fee_rate,
+            merge_largest,
+            change_address = %change_address,
+            pool_total_balance_sat = all_balances.iter().map(|b| u128::from(*b)).sum::<u128>(),
+            pool_balances_desc = ?all_balances,
+            "Active UTXO management: inputs to selection"
+        );
 
         let (out_points, tx_outs) = utxo_utils::choose_utxos_for_active_management(
             utxos,
@@ -1115,6 +1135,8 @@ impl OmniConnector {
             min_deposit_amount.try_into().unwrap(),
             chain,
             self.network()?,
+            merge_largest,
+            max_change_amount,
         )
         .map_err(BridgeSdkError::UtxoManagementError)?;
 

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -547,6 +547,8 @@ pub fn choose_utxos_for_active_management(
     min_deposit_amount: usize,
     chain: ChainKind,
     network: Network,
+    merge_largest: bool,
+    max_change_amount: u128,
 ) -> Result<(Vec<OutPoint>, Vec<TxOut>), String> {
     let mut utxo_list: Vec<(String, UTXO)> = utxos.into_iter().collect();
     utxo_list.sort_by(|a, b| a.1.balance.cmp(&b.1.balance));
@@ -593,9 +595,34 @@ pub fn choose_utxos_for_active_management(
             utxo_list.len() - active_management_limit.1,
             max_active_utxo_management_input_number,
         );
-        for utxo_item in utxo_list.iter().take(utxo_amount) {
-            utxos_balance += utxo_item.1.balance;
-            selected.push(utxo_item.clone());
+        if merge_largest {
+            let half_cap = max_change_amount / 2;
+            for utxo_item in utxo_list.iter().rev() {
+                if selected.len() >= utxo_amount {
+                    break;
+                }
+                let next_balance = u128::from(utxo_item.1.balance);
+                // Skip UTXOs that can't usefully pair with any other big UTXO
+                // without pushing the change output past max_change_amount.
+                if next_balance > half_cap {
+                    continue;
+                }
+                if u128::from(utxos_balance) + next_balance >= max_change_amount {
+                    break;
+                }
+                utxos_balance += utxo_item.1.balance;
+                selected.push(utxo_item.clone());
+            }
+            if selected.is_empty() {
+                return Err(format!(
+                    "merge-largest: no UTXOs <= max_change_amount/2 ({half_cap}); nothing to merge"
+                ));
+            }
+        } else {
+            for utxo_item in utxo_list.iter().take(utxo_amount) {
+                utxos_balance += utxo_item.1.balance;
+                selected.push(utxo_item.clone());
+            }
         }
         let gas_fee: u64 = get_gas_fee(
             chain,

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -538,7 +538,7 @@ pub fn choose_utxos_random_no_payment<R: rand::Rng>(
 #[allow(clippy::implicit_hasher)]
 #[allow(clippy::too_many_arguments)]
 pub fn choose_utxos_for_active_management(
-    utxos: HashMap<String, UTXO>,
+    utxos: &HashMap<String, UTXO>,
     fee_rate: u64,
     change_address: &str,
     active_management_limit: (usize, usize),
@@ -550,17 +550,18 @@ pub fn choose_utxos_for_active_management(
     merge_largest: bool,
     max_change_amount: u128,
 ) -> Result<(Vec<OutPoint>, Vec<TxOut>), String> {
-    let mut utxo_list: Vec<(String, UTXO)> = utxos.into_iter().collect();
+    let mut utxo_list: Vec<(&String, &UTXO)> = utxos.iter().collect();
     utxo_list.sort_by(|a, b| a.1.balance.cmp(&b.1.balance));
 
-    let mut selected = Vec::new();
+    let mut selected: Vec<(String, UTXO)> = Vec::new();
     let mut utxos_balance: u64 = 0;
 
     if utxo_list.len() < active_management_limit.0 {
         let utxo_amount = 1;
         for i in 0..utxo_amount {
             utxos_balance += utxo_list[utxo_list.len() - 1 - i].1.balance;
-            selected.push(utxo_list[i].clone());
+            let (k, v) = utxo_list[i];
+            selected.push((k.clone(), v.clone()));
         }
 
         let output_amount = std::cmp::min(
@@ -611,7 +612,7 @@ pub fn choose_utxos_for_active_management(
                     break;
                 }
                 utxos_balance += utxo_item.1.balance;
-                selected.push(utxo_item.clone());
+                selected.push((utxo_item.0.clone(), utxo_item.1.clone()));
             }
             if selected.is_empty() {
                 return Err(format!(
@@ -621,7 +622,7 @@ pub fn choose_utxos_for_active_management(
         } else {
             for utxo_item in utxo_list.iter().take(utxo_amount) {
                 utxos_balance += utxo_item.1.balance;
-                selected.push(utxo_item.clone());
+                selected.push((utxo_item.0.clone(), utxo_item.1.clone()));
             }
         }
         let gas_fee: u64 = get_gas_fee(

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -603,13 +603,11 @@ pub fn choose_utxos_for_active_management(
                     break;
                 }
                 let next_balance = u128::from(utxo_item.1.balance);
-                // Skip UTXOs that can't usefully pair with any other big UTXO
-                // without pushing the change output past max_change_amount.
                 if next_balance > half_cap {
                     continue;
                 }
                 if u128::from(utxos_balance) + next_balance >= max_change_amount {
-                    break;
+                    continue;
                 }
                 utxos_balance += utxo_item.1.balance;
                 selected.push((utxo_item.0.clone(), utxo_item.1.clone()));

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -612,9 +612,9 @@ pub fn choose_utxos_for_active_management(
                 utxos_balance += utxo_item.1.balance;
                 selected.push((utxo_item.0.clone(), utxo_item.1.clone()));
             }
-            if selected.is_empty() {
+            if selected.len() < 2 {
                 return Err(format!(
-                    "merge-largest: no UTXOs <= max_change_amount/2 ({half_cap}); nothing to merge"
+                    "merge-largest: need at least 2 UTXOs <= max_change_amount/2 ({half_cap}) to merge"
                 ));
             }
         } else {


### PR DESCRIPTION
## Summary
- Adds a `merge_largest` option to active UTXO management that selects the **largest** UTXOs (instead of the smallest) for consolidation. Useful to pre-merge ahead of a large withdrawal so a single big output is available without producing oversized change.
- Bounded by `max_change_amount` from the bridge config: each candidate must be ≤ `max_change_amount / 2`, and selection stops once the accumulated balance would reach `max_change_amount`. Returns a clear error if no eligible UTXOs are available to merge.