### PR TITLE
fix: use correct MPC root key per network for SVM bridge init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.56"
+version = "0.3.57"
 dependencies = [
  "alloy",
  "clap",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "crypto-shared 0.1.0 (git+https://github.com/near-one/mpc?rev=463172481597ee09b12020b72c61d6b01da7b167)",
  "hex-literal",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "alloy",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,7 @@ name = "crypto-utils"
 version = "0.2.1"
 dependencies = [
  "crypto-shared 0.1.0 (git+https://github.com/near-one/mpc?rev=463172481597ee09b12020b72c61d6b01da7b167)",
+ "hex-literal",
  "k256",
  "near-crypto",
  "near-primitives",
@@ -3910,6 +3911,12 @@ checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hex_lit"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.56"
+version = "0.3.57"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1142,7 +1142,11 @@ impl OmniConnector {
             .collect();
         let input_total: u64 = out_points
             .iter()
-            .filter_map(|op| utxos.get(&format!("{}@{}", op.txid, op.vout)).map(|u| u.balance))
+            .filter_map(|op| {
+                utxos
+                    .get(&format!("{}@{}", op.txid, op.vout))
+                    .map(|u| u.balance)
+            })
             .sum();
 
         let outputs_log: Vec<String> = tx_outs
@@ -2198,8 +2202,12 @@ impl OmniConnector {
         program_keypair: Keypair,
     ) -> Result<Signature> {
         let near_bridge_account_id = self.near_bridge_client()?.omni_bridge_id()?;
+        let mpc_root_public_key = match self.network()? {
+            Network::Mainnet => crypto_utils::MPC_ROOT_PUBLIC_KEY_MAINNET,
+            Network::Testnet => crypto_utils::MPC_ROOT_PUBLIC_KEY_TESTNET,
+        };
         let derived_bridge_address =
-            crypto_utils::derive_address(&near_bridge_account_id, "bridge-1");
+            crypto_utils::derive_address(&near_bridge_account_id, "bridge-1", mpc_root_public_key);
 
         let svm_bridge_client = self.svm_bridge_client(chain_kind)?;
 

--- a/bridge-sdk/crypto-utils/Cargo.toml
+++ b/bridge-sdk/crypto-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-utils"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/crypto-utils/Cargo.toml
+++ b/bridge-sdk/crypto-utils/Cargo.toml
@@ -8,3 +8,6 @@ near-crypto.workspace = true
 crypto-shared.workspace = true
 k256.workspace = true
 near-primitives.workspace = true
+
+[dev-dependencies]
+hex-literal = "1"

--- a/bridge-sdk/crypto-utils/src/lib.rs
+++ b/bridge-sdk/crypto-utils/src/lib.rs
@@ -5,10 +5,21 @@ use near_crypto::PublicKey;
 use near_primitives::types::AccountId;
 use std::str::FromStr;
 
-const MPC_KEY: &str = "secp256k1:4NfTiv3UsGahebgTaHyD9vF8KYKMBnfd6kh94mK6xv8fGBiJB8TBtFMP5WWXz6B89Ac1fbpzPwAvoyQebemHFwx3";
+/// NEAR mainnet MPC root public key (signer account `v1.signer`).
+pub const MPC_ROOT_PUBLIC_KEY_MAINNET: &str =
+    "secp256k1:3tFRbMqmoa6AAALMrEFAYCEoHcqKxeW38YptwowBVBtXK1vo36HDbUWuR6EZmoK4JcH6HDkNMGGqP1ouV7VZUWya";
 
-pub fn derive_address(near_account_id: &AccountId, path: &str) -> [u8; 64] {
-    let mpc_key = PublicKey::from_str(MPC_KEY).unwrap();
+/// NEAR testnet MPC root public key (signer account `v1.signer-prod.testnet`).
+/// Also used for the devnet cluster, which shares the testnet MPC contract.
+pub const MPC_ROOT_PUBLIC_KEY_TESTNET: &str =
+    "secp256k1:4NfTiv3UsGahebgTaHyD9vF8KYKMBnfd6kh94mK6xv8fGBiJB8TBtFMP5WWXz6B89Ac1fbpzPwAvoyQebemHFwx3";
+
+pub fn derive_address(
+    near_account_id: &AccountId,
+    path: &str,
+    mpc_root_public_key: &str,
+) -> [u8; 64] {
+    let mpc_key = PublicKey::from_str(mpc_root_public_key).unwrap();
 
     let mut bytes = vec![0x04];
     bytes.extend(mpc_key.key_data());
@@ -22,4 +33,48 @@ pub fn derive_address(near_account_id: &AccountId, path: &str) -> [u8; 64] {
     let slice: &[u8] = &encoded_point.as_bytes()[1..65];
 
     slice.try_into().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pinned to the value stored in the `omni.bridge.near` mainnet bridge `config`
+    // PDA at `2iANpDh96GgithLPTVMZjZFtnbrYBUCLqnEvaytbwTQq` on Solana mainnet — i.e.
+    // what NEAR's MPC actually signs `omni.bridge.near` payloads as. Locks the
+    // (mainnet root key, derive_epsilon, derive_key) tuple against accidental drift;
+    // if this assertion ever fails, every SVM bridge initialized via `svm_initialize`
+    // against mainnet will reject NEAR's signatures with `SignatureVerificationFailed`
+    // (6001).
+    #[test]
+    fn derive_address_matches_mainnet_omni_bridge() {
+        let derived = derive_address(
+            &"omni.bridge.near".parse().unwrap(),
+            "bridge-1",
+            MPC_ROOT_PUBLIC_KEY_MAINNET,
+        );
+        let expected: [u8; 64] = hex_literal::hex!(
+            "afb94f0268153a7e381646308de7e3ee2c77eb314357ef748016ceace6da9553\
+             f25ce6c8d3691b39cf80854a7c377c3a1b9598b0219806140aed2d7bc3f8e04d"
+        );
+        assert_eq!(derived, expected);
+    }
+
+    // Pinned to the value stored in the `omni.n-bridge.testnet` bridge `config`
+    // PDA at `81Eece1nhvt1RhJFo7iPci8oJN7TMjihwevH5WA3tk31` on the Solana testnet
+    // (devnet RPC) deployment. Same regression guard as the mainnet test, but for
+    // the testnet MPC root (signer account `v1.signer-prod.testnet`).
+    #[test]
+    fn derive_address_matches_testnet_omni_bridge() {
+        let derived = derive_address(
+            &"omni.n-bridge.testnet".parse().unwrap(),
+            "bridge-1",
+            MPC_ROOT_PUBLIC_KEY_TESTNET,
+        );
+        let expected: [u8; 64] = hex_literal::hex!(
+            "f378e7100c5c0d62b1e80bf32f8e7e22ef924f309eef1cee4df5f66b2043d862\
+             ba882ece34a38d9d6656355f9537058a93b77f3f6503fe0085b5e15aa47e6f7e"
+        );
+        assert_eq!(derived, expected);
+    }
 }


### PR DESCRIPTION
This pull request updates the MPC root public key handling for address derivation in the bridge SDK, ensuring correct keys are used for mainnet and testnet, and adds regression tests to prevent accidental drift. The changes improve security and maintainability by making the MPC key explicit and testable.

**MPC Root Public Key Handling:**
* Refactored the `derive_address` function in `crypto-utils/src/lib.rs` to accept the MPC root public key as a parameter, replacing the previous hardcoded constant. Added separate constants for mainnet and testnet MPC root public keys.
* Updated all invocations of `derive_address` in `omni_connector.rs` to pass the correct MPC root public key based on the current network (mainnet or testnet).

**Testing and Reliability:**
* Added regression tests to `crypto-utils/src/lib.rs` to verify that address derivation matches the expected values for both mainnet and testnet, preventing accidental changes to the key or derivation logic.
* Added `hex-literal` as a development dependency in `crypto-utils/Cargo.toml` to support the new tests.

**Minor Refactor:**
* Reformatted a closure in `omni_connector.rs` for clarity, with no functional change.