### PR TITLE
feat: support for hypercore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.58"
+version = "0.3.59"
 dependencies = [
  "alloy",
  "clap",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-connector-common"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "alloy",
  "eth-proof",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "evm-bridge-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "alloy",
  "borsh 1.6.1",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "alloy",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,6 +1786,7 @@ dependencies = [
  "clap",
  "dotenv",
  "evm-bridge-client",
+ "hypercore-bridge-client",
  "light-client",
  "near-bridge-client",
  "near-mpc-contract-interface",
@@ -1815,6 +1816,7 @@ dependencies = [
  "alloy",
  "eth-proof",
  "evm-bridge-client",
+ "hypercore-bridge-client",
  "near-rpc-client",
  "serde_json",
  "solana-bridge-client",
@@ -4122,6 +4124,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypercore-bridge-client"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "hex",
+ "omni-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5692,6 +5709,7 @@ dependencies = [
  "eth-proof",
  "evm-bridge-client",
  "hex",
+ "hypercore-bridge-client",
  "light-client",
  "near-bridge-client",
  "near-contract-standards",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "bridge-sdk/bridge-clients/wormhole-bridge-client",
     "bridge-sdk/bridge-clients/utxo-bridge-client",
     "bridge-sdk/bridge-clients/starknet-bridge-client",
+    "bridge-sdk/bridge-clients/hypercore-bridge-client",
     "bridge-sdk/crypto-utils",
     "bridge-sdk/utxo-utils",
     "bridge-sdk/light-client"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.58"
+version = "0.3.59"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -27,6 +27,7 @@ solana-bridge-client = { path = "../bridge-sdk/bridge-clients/solana-bridge-clie
 wormhole-bridge-client = { path = "../bridge-sdk/bridge-clients/wormhole-bridge-client" }
 utxo-bridge-client = { path = "../bridge-sdk/bridge-clients/utxo-bridge-client" }
 starknet-bridge-client = { path = "../bridge-sdk/bridge-clients/starknet-bridge-client" }
+hypercore-bridge-client = { path = "../bridge-sdk/bridge-clients/hypercore-bridge-client" }
 utxo-utils = { path = "../bridge-sdk/utxo-utils" }
 near-sdk.workspace = true
 near-mpc-contract-interface.workspace = true

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -33,8 +33,16 @@ pub const POL_WORMHOLE_ADDRESS_MAINNET: &str = "0x7A4B5a56256163F07b2C80A7cA55aB
 
 pub const HYPEREVM_RPC_MAINNET: &str = "https://rpc.hyperliquid.xyz/evm";
 pub const HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS_MAINNET: &str =
-    "0x0000000000000000000000000000000000000000";
+    "0xf353b40fC144d1c6c5BCdda712fa6De833016aF9";
 pub const HYPEREVM_WORMHOLE_ADDRESS_MAINNET: &str = "0x7C0faFc4384551f063e05aee704ab943b8B53aB3";
+
+pub const HYPERCORE_API_MAINNET: &str = "https://api.hyperliquid.xyz";
+// Match the Hyperliquid Python SDK convention (signing.py:250) which uses
+// 0x66eee (Arb-Sepolia) for the EIP-712 domain on both mainnet and testnet.
+// The signatureChainId only needs to be unique across chains to prevent
+// signature replay; both 0xa4b1 (Arbitrum) and 0x66eee work, but mirroring
+// the canonical SDK reduces interop surprises.
+pub const HYPERCORE_SIGNATURE_CHAIN_ID_MAINNET: &str = "0x66eee";
 
 pub const ABS_RPC_MAINNET: &str = "https://api.mainnet.abs.xyz";
 pub const ABS_BRIDGE_TOKEN_FACTORY_ADDRESS_MAINNET: &str =
@@ -107,8 +115,11 @@ pub const POL_WORMHOLE_ADDRESS_TESTNET: &str = "0x6b9C8671cdDC8dEab9c719bB87cBd3
 
 pub const HYPEREVM_RPC_TESTNET: &str = "https://rpc.hyperliquid-testnet.xyz/evm";
 pub const HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET: &str =
-    "0x0000000000000000000000000000000000000000";
+    "0xf353b40fC144d1c6c5BCdda712fa6De833016aF9";
 pub const HYPEREVM_WORMHOLE_ADDRESS_TESTNET: &str = "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd";
+
+pub const HYPERCORE_API_TESTNET: &str = "https://api.hyperliquid-testnet.xyz";
+pub const HYPERCORE_SIGNATURE_CHAIN_ID_TESTNET: &str = "0x66eee";
 
 pub const ABS_RPC_TESTNET: &str = "https://api.testnet.abs.xyz";
 pub const ABS_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET: &str =
@@ -181,8 +192,11 @@ pub const POL_WORMHOLE_ADDRESS_DEVNET: &str = "0x6b9C8671cdDC8dEab9c719bB87cBd3e
 
 pub const HYPEREVM_RPC_DEVNET: &str = "https://rpc.hyperliquid-testnet.xyz/evm";
 pub const HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET: &str =
-    "0x0000000000000000000000000000000000000000";
+    "0xf353b40fC144d1c6c5BCdda712fa6De833016aF9";
 pub const HYPEREVM_WORMHOLE_ADDRESS_DEVNET: &str = "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd";
+
+pub const HYPERCORE_API_DEVNET: &str = HYPERCORE_API_TESTNET;
+pub const HYPERCORE_SIGNATURE_CHAIN_ID_DEVNET: &str = HYPERCORE_SIGNATURE_CHAIN_ID_TESTNET;
 
 pub const ABS_RPC_DEVNET: &str = "https://api.testnet.abs.xyz";
 pub const ABS_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET: &str =

--- a/bridge-cli/src/main.rs
+++ b/bridge-cli/src/main.rs
@@ -83,6 +83,11 @@ struct CliConfig {
     hyperevm_wormhole_address: Option<String>,
 
     #[arg(long)]
+    hypercore_api: Option<String>,
+    #[arg(long)]
+    hypercore_signature_chain_id: Option<String>,
+
+    #[arg(long)]
     abs_rpc: Option<String>,
     #[arg(long)]
     abs_private_key: Option<String>,
@@ -217,6 +222,11 @@ impl CliConfig {
                 .hyperevm_wormhole_address
                 .or(other.hyperevm_wormhole_address),
 
+            hypercore_api: self.hypercore_api.or(other.hypercore_api),
+            hypercore_signature_chain_id: self
+                .hypercore_signature_chain_id
+                .or(other.hypercore_signature_chain_id),
+
             abs_rpc: self.abs_rpc.or(other.abs_rpc),
             abs_private_key: self.abs_private_key.or(other.abs_private_key),
             abs_bridge_token_factory_address: self
@@ -319,6 +329,9 @@ fn env_config() -> CliConfig {
         hyperevm_bridge_token_factory_address: env::var("HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS")
             .ok(),
         hyperevm_wormhole_address: env::var("HYPEREVM_WORMHOLE_ADDRESS").ok(),
+
+        hypercore_api: env::var("HYPERCORE_API").ok(),
+        hypercore_signature_chain_id: env::var("HYPERCORE_SIGNATURE_CHAIN_ID").ok(),
 
         abs_rpc: env::var("ABS_RPC").ok(),
         abs_private_key: env::var("ABS_PRIVATE_KEY").ok(),
@@ -431,6 +444,11 @@ fn default_config(network: Network) -> CliConfig {
             ),
             hyperevm_wormhole_address: Some(defaults::HYPEREVM_WORMHOLE_ADDRESS_MAINNET.to_owned()),
 
+            hypercore_api: Some(defaults::HYPERCORE_API_MAINNET.to_owned()),
+            hypercore_signature_chain_id: Some(
+                defaults::HYPERCORE_SIGNATURE_CHAIN_ID_MAINNET.to_owned(),
+            ),
+
             abs_rpc: Some(defaults::ABS_RPC_MAINNET.to_owned()),
             abs_private_key: None,
             abs_bridge_token_factory_address: Some(
@@ -535,6 +553,11 @@ fn default_config(network: Network) -> CliConfig {
                 defaults::HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET.to_owned(),
             ),
             hyperevm_wormhole_address: Some(defaults::HYPEREVM_WORMHOLE_ADDRESS_TESTNET.to_owned()),
+
+            hypercore_api: Some(defaults::HYPERCORE_API_TESTNET.to_owned()),
+            hypercore_signature_chain_id: Some(
+                defaults::HYPERCORE_SIGNATURE_CHAIN_ID_TESTNET.to_owned(),
+            ),
 
             abs_rpc: Some(defaults::ABS_RPC_TESTNET.to_owned()),
             abs_private_key: None,
@@ -641,6 +664,11 @@ fn default_config(network: Network) -> CliConfig {
                 defaults::HYPEREVM_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET.to_owned(),
             ),
             hyperevm_wormhole_address: Some(defaults::HYPEREVM_WORMHOLE_ADDRESS_DEVNET.to_owned()),
+
+            hypercore_api: Some(defaults::HYPERCORE_API_DEVNET.to_owned()),
+            hypercore_signature_chain_id: Some(
+                defaults::HYPERCORE_SIGNATURE_CHAIN_ID_DEVNET.to_owned(),
+            ),
 
             abs_rpc: Some(defaults::ABS_RPC_DEVNET.to_owned()),
             abs_private_key: None,

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -7,6 +7,7 @@ use std::{path::Path, str::FromStr};
 use alloy::primitives::{Address as EvmH160, TxHash};
 use alloy::signers::local::PrivateKeySigner;
 use evm_bridge_client::EvmBridgeClientBuilder;
+use hypercore_bridge_client::{HyperCoreBridgeClientBuilder, HyperliquidNetwork};
 use light_client::LightClientBuilder;
 use near_bridge_client::{
     btc::{format_max_gas_fee, DepositMsg, SafeDepositMsg},
@@ -469,6 +470,46 @@ pub enum OmniConnectorSubCommand {
         config_cli: CliConfig,
     },
 
+    #[clap(about = "HyperCore -> NEAR/other chain via sendToEvmWithData (ACTION_INIT_TRANSFER)")]
+    HyperCoreInitTransfer {
+        #[clap(long, help = "Hyperliquid spot token identifier, e.g. PURR:0x<32hex>")]
+        token: String,
+        #[clap(long, help = "HlBridgeToken contract address on HyperEVM")]
+        hl_token: EvmH160,
+        #[clap(short, long, help = "Amount in bridge ERC20 wei units")]
+        amount: u128,
+        #[clap(long, help = "Bridge token decimals")]
+        decimals: u8,
+        #[clap(short, long, help = "Recipient OmniAddress (near:..., sol:..., etc.)")]
+        recipient: OmniAddress,
+        #[clap(short, long, help = "Bridge fee (in bridge ERC20 wei units)")]
+        fee: Option<u128>,
+        #[clap(short, long, help = "Additional message routed through the bridge")]
+        message: Option<String>,
+        #[clap(long, help = "Override HyperEVM gas limit for the system call")]
+        gas_limit: Option<u64>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
+    #[clap(
+        about = "HyperCore -> HyperEVM via sendToEvmWithData (ACTION_TRANSFER): pool release to an EVM recipient"
+    )]
+    HyperCoreEvmTransfer {
+        #[clap(long, help = "Hyperliquid spot token identifier, e.g. PURR:0x<32hex>")]
+        token: String,
+        #[clap(long, help = "HlBridgeToken contract address on HyperEVM")]
+        hl_token: EvmH160,
+        #[clap(short, long, help = "Amount in bridge ERC20 wei units")]
+        amount: u128,
+        #[clap(long, help = "Bridge token decimals")]
+        decimals: u8,
+        #[clap(short = 'r', long, help = "HyperEVM recipient address")]
+        evm_recipient: EvmH160,
+        #[clap(long, help = "Override HyperEVM gas limit for the system call")]
+        gas_limit: Option<u64>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
     #[clap(about = "Initialize a transfer on Starknet")]
     StarknetInitTransfer {
         #[clap(short, long, help = "Token address on Starknet (felt hex)")]
@@ -1258,6 +1299,53 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .unwrap();
         }
 
+        OmniConnectorSubCommand::HyperCoreInitTransfer {
+            token,
+            hl_token,
+            amount,
+            decimals,
+            recipient,
+            fee,
+            message,
+            gas_limit,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .init_transfer(InitTransferArgs::HyperCoreInitTransfer {
+                    token,
+                    hl_bridge_token: hl_token,
+                    amount,
+                    decimals,
+                    recipient,
+                    fee: fee.unwrap_or_default(),
+                    message: message.unwrap_or_default(),
+                    gas_limit,
+                })
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::HyperCoreEvmTransfer {
+            token,
+            hl_token,
+            amount,
+            decimals,
+            evm_recipient,
+            gas_limit,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .init_transfer(InitTransferArgs::HyperCoreEvmTransfer {
+                    token,
+                    hl_bridge_token: hl_token,
+                    amount,
+                    decimals,
+                    evm_recipient,
+                    gas_limit,
+                })
+                .await
+                .unwrap();
+        }
+
         OmniConnectorSubCommand::StarknetInitTransfer {
             token,
             amount,
@@ -1948,8 +2036,8 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .unwrap();
 
     let hyperevm_bridge_client = EvmBridgeClientBuilder::default()
-        .endpoint(combined_config.hyperevm_rpc)
-        .private_key(combined_config.hyperevm_private_key)
+        .endpoint(combined_config.hyperevm_rpc.clone())
+        .private_key(combined_config.hyperevm_private_key.clone())
         .omni_bridge_address(combined_config.hyperevm_bridge_token_factory_address)
         .wormhole_core_address(combined_config.hyperevm_wormhole_address)
         .build()
@@ -1963,6 +2051,23 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .mpc_finality(Some(EvmFinality::Latest))
         .build()
         .unwrap();
+
+    let hypercore_network = match network {
+        Network::Mainnet => HyperliquidNetwork::Mainnet,
+        Network::Testnet | Network::Devnet => HyperliquidNetwork::Testnet,
+    };
+    let hypercore_bridge_client = combined_config.hyperevm_private_key.as_ref().map(|pk| {
+        HyperCoreBridgeClientBuilder::default()
+            .network(hypercore_network)
+            .api_url(combined_config.hypercore_api.clone())
+            .hyperevm_rpc_url(combined_config.hyperevm_rpc.clone())
+            .private_key(Some(pk.clone()))
+            .signature_chain_id(combined_config.hypercore_signature_chain_id.clone())
+            .poll_interval(None)
+            .poll_timeout(None)
+            .build()
+            .unwrap()
+    });
 
     let solana_bridge_client = SolanaBridgeClientBuilder::default()
         .chain(Some(ChainKind::Sol))
@@ -2110,6 +2215,7 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .pol_bridge_client(Some(pol_bridge_client))
         .hyperevm_bridge_client(Some(hyperevm_bridge_client))
         .abs_bridge_client(Some(abs_bridge_client))
+        .hypercore_bridge_client(hypercore_bridge_client)
         .solana_bridge_client(Some(solana_bridge_client))
         .fogo_bridge_client(Some(fogo_bridge_client))
         .starknet_bridge_client(Some(starknet_bridge_client))

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -470,8 +470,10 @@ pub enum OmniConnectorSubCommand {
         config_cli: CliConfig,
     },
 
-    #[clap(about = "HyperCore -> NEAR/other chain via sendToEvmWithData (ACTION_INIT_TRANSFER)")]
-    HyperCoreInitTransfer {
+    #[clap(about = "HyperCore -> any destination via sendToEvmWithData. \
+                 hlevm:0x... recipient uses ACTION_TRANSFER (direct pool release on HyperEVM); \
+                 any other recipient uses ACTION_INIT_TRANSFER (route through OmniBridge).")]
+    HyperCoreTransfer {
         #[clap(long, help = "Hyperliquid spot token identifier, e.g. PURR:0x<32hex>")]
         token: String,
         #[clap(long, help = "HlBridgeToken contract address on HyperEVM")]
@@ -480,31 +482,24 @@ pub enum OmniConnectorSubCommand {
         amount: u128,
         #[clap(long, help = "Bridge token decimals")]
         decimals: u8,
-        #[clap(short, long, help = "Recipient OmniAddress (near:..., sol:..., etc.)")]
+        #[clap(
+            short,
+            long,
+            help = "Recipient OmniAddress: hlevm:0x... (pool release on HyperEVM) or near:... / sol:... / eth:0x... etc. (bridge)"
+        )]
         recipient: OmniAddress,
-        #[clap(short, long, help = "Bridge fee (in bridge ERC20 wei units)")]
+        #[clap(
+            short,
+            long,
+            help = "Bridge fee in bridge ERC20 wei units (ignored when recipient is hlevm:)"
+        )]
         fee: Option<u128>,
-        #[clap(short, long, help = "Additional message routed through the bridge")]
+        #[clap(
+            short,
+            long,
+            help = "Additional message routed through the bridge (ignored when recipient is hlevm:)"
+        )]
         message: Option<String>,
-        #[clap(long, help = "Override HyperEVM gas limit for the system call")]
-        gas_limit: Option<u64>,
-        #[command(flatten)]
-        config_cli: CliConfig,
-    },
-    #[clap(
-        about = "HyperCore -> HyperEVM via sendToEvmWithData (ACTION_TRANSFER): pool release to an EVM recipient"
-    )]
-    HyperCoreEvmTransfer {
-        #[clap(long, help = "Hyperliquid spot token identifier, e.g. PURR:0x<32hex>")]
-        token: String,
-        #[clap(long, help = "HlBridgeToken contract address on HyperEVM")]
-        hl_token: EvmH160,
-        #[clap(short, long, help = "Amount in bridge ERC20 wei units")]
-        amount: u128,
-        #[clap(long, help = "Bridge token decimals")]
-        decimals: u8,
-        #[clap(short = 'r', long, help = "HyperEVM recipient address")]
-        evm_recipient: EvmH160,
         #[clap(long, help = "Override HyperEVM gas limit for the system call")]
         gas_limit: Option<u64>,
         #[command(flatten)]
@@ -1299,7 +1294,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                 .unwrap();
         }
 
-        OmniConnectorSubCommand::HyperCoreInitTransfer {
+        OmniConnectorSubCommand::HyperCoreTransfer {
             token,
             hl_token,
             amount,
@@ -1311,7 +1306,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             config_cli,
         } => {
             omni_connector(network, config_cli)
-                .init_transfer(InitTransferArgs::HyperCoreInitTransfer {
+                .init_transfer(InitTransferArgs::HyperCoreTransfer {
                     token,
                     hl_bridge_token: hl_token,
                     amount,
@@ -1319,27 +1314,6 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     recipient,
                     fee: fee.unwrap_or_default(),
                     message: message.unwrap_or_default(),
-                    gas_limit,
-                })
-                .await
-                .unwrap();
-        }
-        OmniConnectorSubCommand::HyperCoreEvmTransfer {
-            token,
-            hl_token,
-            amount,
-            decimals,
-            evm_recipient,
-            gas_limit,
-            config_cli,
-        } => {
-            omni_connector(network, config_cli)
-                .init_transfer(InitTransferArgs::HyperCoreEvmTransfer {
-                    token,
-                    hl_bridge_token: hl_token,
-                    amount,
-                    decimals,
-                    evm_recipient,
                     gas_limit,
                 })
                 .await

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -476,12 +476,18 @@ pub enum OmniConnectorSubCommand {
     HyperCoreTransfer {
         #[clap(long, help = "Hyperliquid spot token identifier, e.g. PURR:0x<32hex>")]
         token: String,
-        #[clap(long, help = "HlBridgeToken contract address on HyperEVM")]
-        hl_token: EvmH160,
+        #[clap(
+            long,
+            help = "HlBridgeToken contract address on HyperEVM (resolved from spotMeta if omitted)"
+        )]
+        hl_token: Option<EvmH160>,
         #[clap(short, long, help = "Amount in bridge ERC20 wei units")]
         amount: u128,
-        #[clap(long, help = "Bridge token decimals")]
-        decimals: u8,
+        #[clap(
+            long,
+            help = "Bridge token decimals (resolved from spotMeta if omitted)"
+        )]
+        decimals: Option<u8>,
         #[clap(
             short,
             long,

--- a/bridge-sdk/bridge-clients/evm-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-bridge-client"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
@@ -86,8 +86,16 @@ sol! {
     }
 }
 
+sol! {
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    interface HlBridgeToken {
+        event CoreReceived(address indexed sender, uint8 indexed action, uint256 amount, bytes data);
+    }
+}
+
 // Helper type for InitTransferFilter compatibility
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InitTransferFilter {
     pub sender: Address,
     pub token_address: Address,
@@ -97,6 +105,29 @@ pub struct InitTransferFilter {
     pub native_fee: u128,
     pub recipient: String,
     pub message: String,
+}
+
+/// Decoded `HlBridgeToken.CoreReceived` event. `sender` is the originating
+/// HyperCore user (passed through as `from`); `data` is the full
+/// `tag || abi.encoded payload` bytes.
+#[derive(Debug, Clone)]
+pub struct CoreReceivedFilter {
+    pub sender: Address,
+    pub action: u8,
+    pub amount: U256,
+    pub data: Bytes,
+}
+
+/// Pair of events emitted in the same HyperEVM tx when a HyperCore user
+/// triggers `ACTION_INIT_TRANSFER` on an HlBridgeToken:
+/// - `CoreReceived` carries the originating Core user (`sender`).
+/// - `InitTransfer` is emitted by `OmniBridge`, but its `sender` field is the
+///   HlBridgeToken contract address, not the Core user. Correlate the two to
+///   attribute the transfer back to the originating HyperCore account.
+#[derive(Debug, Clone)]
+pub struct CoreInitiatedTransfer {
+    pub init_transfer: InitTransferFilter,
+    pub core_received: CoreReceivedFilter,
 }
 
 /// Bridging NEAR-originated NEP-141 tokens to EVM and back
@@ -489,6 +520,79 @@ impl EvmBridgeClient {
     pub async fn get_init_transfer_log(&self, tx_hash: TxHash) -> Result<alloy::rpc::types::Log> {
         self.get_event_log(tx_hash, OmniBridge::InitTransfer::SIGNATURE)
             .await
+    }
+
+    /// Fetches the `HlBridgeToken.CoreReceived` log emitted by `hl_bridge_token`
+    /// in the receipt of `tx_hash`. Use this to verify that a HyperCore-originated
+    /// `sendToEvmWithData` action landed on HyperEVM as expected.
+    pub async fn get_core_received_log(
+        &self,
+        tx_hash: TxHash,
+        hl_bridge_token: Address,
+    ) -> Result<alloy::rpc::types::Log> {
+        let sig_hash =
+            alloy::primitives::keccak256(HlBridgeToken::CoreReceived::SIGNATURE.as_bytes());
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(EvmBridgeClientError::BlockchainDataError(
+                "Transaction receipt missing".to_string(),
+            ))?;
+
+        receipt
+            .inner
+            .into_logs()
+            .into_iter()
+            .find(|log| {
+                log.address() == hl_bridge_token
+                    && log
+                        .topics()
+                        .first()
+                        .is_some_and(|topic| topic.0 == sig_hash.0)
+            })
+            .ok_or(EvmBridgeClientError::BlockchainDataError(format!(
+                "CoreReceived log from {hl_bridge_token:?} missing in tx {tx_hash}"
+            )))
+    }
+
+    /// Correlates `InitTransfer` and `CoreReceived` in the same HyperEVM tx.
+    ///
+    /// `InitTransfer.sender` is the HlBridgeToken contract address (not the
+    /// HyperCore user) when the transfer was initiated via the
+    /// `ACTION_INIT_TRANSFER` callback. The originating Core user is recoverable
+    /// only from the `CoreReceived` log, which carries `sender == from`.
+    pub async fn parse_core_initiated_transfer(
+        &self,
+        tx_hash: TxHash,
+        hl_bridge_token: Address,
+    ) -> Result<CoreInitiatedTransfer> {
+        let init_transfer = self.get_transfer_event(tx_hash).await?;
+
+        let core_log = self.get_core_received_log(tx_hash, hl_bridge_token).await?;
+        let decoded =
+            HlBridgeToken::CoreReceived::decode_log(&core_log.into_inner()).map_err(|err| {
+                EvmBridgeClientError::BlockchainDataError(format!(
+                    "Failed to decode CoreReceived log: {err}"
+                ))
+            })?;
+
+        let HlBridgeToken::CoreReceived {
+            sender,
+            action,
+            amount,
+            data,
+        } = decoded.data;
+
+        Ok(CoreInitiatedTransfer {
+            init_transfer,
+            core_received: CoreReceivedFilter {
+                sender,
+                action,
+                amount,
+                data,
+            },
+        })
     }
 
     pub async fn get_deploy_token_log(&self, tx_hash: TxHash) -> Result<alloy::rpc::types::Log> {

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "hypercore-bridge-client"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.88.0"
+
+[dependencies]
+alloy.workspace = true
+hex.workspace = true
+omni-types.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[lib]
+path = "src/hypercore_bridge_client.rs"

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/action.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/action.rs
@@ -1,0 +1,117 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HyperliquidNetwork {
+    Mainnet,
+    Testnet,
+}
+
+impl HyperliquidNetwork {
+    #[must_use]
+    pub fn api_url(self) -> &'static str {
+        match self {
+            Self::Mainnet => "https://api.hyperliquid.xyz",
+            Self::Testnet => "https://api.hyperliquid-testnet.xyz",
+        }
+    }
+
+    #[must_use]
+    pub fn hyperliquid_chain(self) -> &'static str {
+        match self {
+            Self::Mainnet => "Mainnet",
+            Self::Testnet => "Testnet",
+        }
+    }
+
+    #[must_use]
+    pub fn hyperevm_chain_id(self) -> u32 {
+        match self {
+            Self::Mainnet => 999,
+            Self::Testnet => 998,
+        }
+    }
+
+    #[must_use]
+    pub fn default_hyperevm_rpc(self) -> &'static str {
+        match self {
+            Self::Mainnet => "https://rpc.hyperliquid.xyz/evm",
+            Self::Testnet => "https://rpc.hyperliquid-testnet.xyz/evm",
+        }
+    }
+}
+
+/// JSON body of a `sendToEvmWithData` Hyperliquid Core action.
+///
+/// Field order matches the inferred EIP-712 type list; reordering will change the
+/// type hash and invalidate signatures.
+#[derive(Debug, Clone, Serialize)]
+pub struct SendToEvmWithDataAction {
+    #[serde(rename = "type")]
+    pub action_type: &'static str,
+    #[serde(rename = "hyperliquidChain")]
+    pub hyperliquid_chain: &'static str,
+    #[serde(rename = "signatureChainId")]
+    pub signature_chain_id: String,
+    pub token: String,
+    pub amount: String,
+    #[serde(rename = "sourceDex")]
+    pub source_dex: String,
+    #[serde(rename = "destinationRecipient")]
+    pub destination_recipient: String,
+    #[serde(rename = "addressEncoding")]
+    pub address_encoding: String,
+    #[serde(rename = "destinationChainId")]
+    pub destination_chain_id: u32,
+    #[serde(rename = "gasLimit")]
+    pub gas_limit: u64,
+    pub data: String,
+    pub nonce: u64,
+}
+
+/// Format an integer amount + decimals as a minimal Hyperliquid decimal string
+/// (no trailing zeros, no leading zeros except a single `0` before the decimal point).
+#[must_use]
+pub fn format_amount(amount: u128, decimals: u8) -> String {
+    if decimals == 0 {
+        return amount.to_string();
+    }
+    let raw = amount.to_string();
+    let dec = decimals as usize;
+    if raw.len() <= dec {
+        let mut frac = "0".repeat(dec - raw.len());
+        frac.push_str(&raw);
+        let trimmed = frac.trim_end_matches('0');
+        if trimmed.is_empty() {
+            "0".to_string()
+        } else {
+            format!("0.{trimmed}")
+        }
+    } else {
+        let split = raw.len() - dec;
+        let int = &raw[..split];
+        let frac = raw[split..].trim_end_matches('0');
+        if frac.is_empty() {
+            int.to_string()
+        } else {
+            format!("{int}.{frac}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_amount_examples() {
+        assert_eq!(format_amount(0, 8), "0");
+        assert_eq!(format_amount(1, 8), "0.00000001");
+        assert_eq!(format_amount(100_000_000, 8), "1");
+        assert_eq!(format_amount(123_456_789, 8), "1.23456789");
+        assert_eq!(format_amount(100_000_000_000, 8), "1000");
+        assert_eq!(format_amount(10, 0), "10");
+        assert_eq!(format_amount(1_000, 2), "10");
+        assert_eq!(format_amount(123, 2), "1.23");
+        assert_eq!(format_amount(120, 2), "1.2");
+    }
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/action.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/action.rs
@@ -7,14 +7,7 @@ pub enum HyperliquidNetwork {
 }
 
 impl HyperliquidNetwork {
-    #[must_use]
-    pub fn api_url(self) -> &'static str {
-        match self {
-            Self::Mainnet => "https://api.hyperliquid.xyz",
-            Self::Testnet => "https://api.hyperliquid-testnet.xyz",
-        }
-    }
-
+    /// `hyperliquidChain` value embedded in the signed action JSON.
     #[must_use]
     pub fn hyperliquid_chain(self) -> &'static str {
         match self {
@@ -23,19 +16,12 @@ impl HyperliquidNetwork {
         }
     }
 
+    /// HyperEVM chain id (`destinationChainId` in the action JSON).
     #[must_use]
     pub fn hyperevm_chain_id(self) -> u32 {
         match self {
             Self::Mainnet => 999,
             Self::Testnet => 998,
-        }
-    }
-
-    #[must_use]
-    pub fn default_hyperevm_rpc(self) -> &'static str {
-        match self {
-            Self::Mainnet => "https://rpc.hyperliquid.xyz/evm",
-            Self::Testnet => "https://rpc.hyperliquid-testnet.xyz/evm",
         }
     }
 }

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
@@ -106,9 +106,7 @@ impl HyperCoreBridgeClientBuilder {
         })?;
 
         let api_url = self.api_url.ok_or_else(|| {
-            HyperCoreBridgeClientError::ConfigError(
-                "Hyperliquid api_url is required".to_string(),
-            )
+            HyperCoreBridgeClientError::ConfigError("Hyperliquid api_url is required".to_string())
         })?;
         let hyperevm_rpc_url = self.hyperevm_rpc_url.ok_or_else(|| {
             HyperCoreBridgeClientError::ConfigError(

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
@@ -1,0 +1,149 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use alloy::providers::{Provider, ProviderBuilder};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::transports::http::reqwest::Url;
+
+use crate::action::HyperliquidNetwork;
+use crate::error::{HyperCoreBridgeClientError, Result};
+use crate::HyperCoreBridgeClient;
+
+/// Default Arbitrum-Sepolia chain id for `signatureChainId`, matching the
+/// Hyperliquid Python SDK default (signing.py:250).
+const DEFAULT_SIGNATURE_CHAIN_ID: &str = "0x66eee";
+
+const DEFAULT_POLL_INTERVAL_MS: u64 = 1500;
+const DEFAULT_POLL_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_HTTP_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Default)]
+pub struct HyperCoreBridgeClientBuilder {
+    network: Option<HyperliquidNetwork>,
+    api_url: Option<String>,
+    hyperevm_rpc_url: Option<String>,
+    private_key: Option<String>,
+    signature_chain_id: Option<String>,
+    poll_interval: Option<Duration>,
+    poll_timeout: Option<Duration>,
+    http_timeout: Option<Duration>,
+}
+
+impl HyperCoreBridgeClientBuilder {
+    #[must_use]
+    pub fn network(mut self, network: HyperliquidNetwork) -> Self {
+        self.network = Some(network);
+        self
+    }
+
+    /// Override the Hyperliquid REST base URL (defaults to the per-network value).
+    /// Provide the BASE URL without the `/exchange` suffix.
+    #[must_use]
+    pub fn api_url(mut self, api_url: Option<String>) -> Self {
+        self.api_url = api_url;
+        self
+    }
+
+    /// Override the HyperEVM RPC URL used for the post-action `CoreReceived` poll.
+    #[must_use]
+    pub fn hyperevm_rpc_url(mut self, hyperevm_rpc_url: Option<String>) -> Self {
+        self.hyperevm_rpc_url = hyperevm_rpc_url;
+        self
+    }
+
+    /// EOA private key (hex, optionally `0x`-prefixed). Same key the user uses
+    /// for HyperEVM transactions — Hyperliquid action signing reuses it.
+    #[must_use]
+    pub fn private_key(mut self, private_key: Option<String>) -> Self {
+        self.private_key = private_key;
+        self
+    }
+
+    /// Wallet chain id encoded as a hex string (e.g. `"0xa4b1"` for Arbitrum).
+    /// This goes into the action `signatureChainId` field and the EIP-712 domain;
+    /// the constraint is only that signatures don't replay across chains.
+    /// Defaults to `0x66eee` (Arb-Sepolia), matching the Python SDK default.
+    #[must_use]
+    pub fn signature_chain_id(mut self, signature_chain_id: Option<String>) -> Self {
+        self.signature_chain_id = signature_chain_id;
+        self
+    }
+
+    #[must_use]
+    pub fn poll_interval(mut self, poll_interval: Option<Duration>) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    #[must_use]
+    pub fn poll_timeout(mut self, poll_timeout: Option<Duration>) -> Self {
+        self.poll_timeout = poll_timeout;
+        self
+    }
+
+    /// Per-request timeout applied to `/exchange` POSTs. Without this, a hung
+    /// Hyperliquid API connection would block the call indefinitely (the poll
+    /// timeout only covers the EVM-side wait). Default 30s.
+    #[must_use]
+    pub fn http_timeout(mut self, http_timeout: Option<Duration>) -> Self {
+        self.http_timeout = http_timeout;
+        self
+    }
+
+    pub fn build(self) -> Result<HyperCoreBridgeClient> {
+        let network = self.network.ok_or_else(|| {
+            HyperCoreBridgeClientError::ConfigError("network is required".to_string())
+        })?;
+
+        let private_key = self.private_key.ok_or_else(|| {
+            HyperCoreBridgeClientError::ConfigError("private_key is required".to_string())
+        })?;
+        let signer = PrivateKeySigner::from_str(&private_key).map_err(|_| {
+            HyperCoreBridgeClientError::ConfigError("Invalid HyperCore private key".to_string())
+        })?;
+
+        let api_url = self
+            .api_url
+            .unwrap_or_else(|| network.api_url().to_string());
+        let hyperevm_rpc_url = self
+            .hyperevm_rpc_url
+            .unwrap_or_else(|| network.default_hyperevm_rpc().to_string());
+
+        let rpc_url: Url = hyperevm_rpc_url.parse().map_err(|_| {
+            HyperCoreBridgeClientError::ConfigError(
+                "Invalid HyperEVM RPC URL for HyperCore polling".to_string(),
+            )
+        })?;
+        let hyperevm_provider = ProviderBuilder::new().connect_http(rpc_url).erased();
+
+        let http_timeout = self
+            .http_timeout
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECS));
+        let http_client = reqwest::Client::builder()
+            .timeout(http_timeout)
+            .build()
+            .map_err(|e| HyperCoreBridgeClientError::Http(e.to_string()))?;
+
+        let signature_chain_id = self
+            .signature_chain_id
+            .unwrap_or_else(|| DEFAULT_SIGNATURE_CHAIN_ID.to_string());
+
+        let poll_interval = self
+            .poll_interval
+            .unwrap_or_else(|| Duration::from_millis(DEFAULT_POLL_INTERVAL_MS));
+        let poll_timeout = self
+            .poll_timeout
+            .unwrap_or_else(|| Duration::from_secs(DEFAULT_POLL_TIMEOUT_SECS));
+
+        Ok(HyperCoreBridgeClient {
+            network,
+            api_url,
+            hyperevm_provider,
+            signer,
+            http_client,
+            signature_chain_id,
+            poll_interval,
+            poll_timeout,
+        })
+    }
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/builder.rs
@@ -36,15 +36,18 @@ impl HyperCoreBridgeClientBuilder {
         self
     }
 
-    /// Override the Hyperliquid REST base URL (defaults to the per-network value).
-    /// Provide the BASE URL without the `/exchange` suffix.
+    /// Hyperliquid REST base URL. Required. Provide the BASE URL without the
+    /// `/exchange` suffix. The caller is the source of truth — see
+    /// `bridge-cli/src/defaults.rs::HYPERCORE_API_*`.
     #[must_use]
     pub fn api_url(mut self, api_url: Option<String>) -> Self {
         self.api_url = api_url;
         self
     }
 
-    /// Override the HyperEVM RPC URL used for the post-action `CoreReceived` poll.
+    /// HyperEVM RPC URL used for the post-action `CoreReceived` poll.
+    /// Required. The caller is the source of truth — see
+    /// `bridge-cli/src/defaults.rs::HYPEREVM_RPC_*`.
     #[must_use]
     pub fn hyperevm_rpc_url(mut self, hyperevm_rpc_url: Option<String>) -> Self {
         self.hyperevm_rpc_url = hyperevm_rpc_url;
@@ -102,12 +105,16 @@ impl HyperCoreBridgeClientBuilder {
             HyperCoreBridgeClientError::ConfigError("Invalid HyperCore private key".to_string())
         })?;
 
-        let api_url = self
-            .api_url
-            .unwrap_or_else(|| network.api_url().to_string());
-        let hyperevm_rpc_url = self
-            .hyperevm_rpc_url
-            .unwrap_or_else(|| network.default_hyperevm_rpc().to_string());
+        let api_url = self.api_url.ok_or_else(|| {
+            HyperCoreBridgeClientError::ConfigError(
+                "Hyperliquid api_url is required".to_string(),
+            )
+        })?;
+        let hyperevm_rpc_url = self.hyperevm_rpc_url.ok_or_else(|| {
+            HyperCoreBridgeClientError::ConfigError(
+                "hyperevm_rpc_url is required (used for CoreReceived polling)".to_string(),
+            )
+        })?;
 
         let rpc_url: Url = hyperevm_rpc_url.parse().map_err(|_| {
             HyperCoreBridgeClientError::ConfigError(

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/encoders.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/encoders.rs
@@ -1,0 +1,76 @@
+use alloy::primitives::Address;
+use alloy::sol_types::SolValue;
+use omni_types::OmniAddress;
+
+pub const ACTION_TRANSFER: u8 = 0x00;
+pub const ACTION_INIT_TRANSFER: u8 = 0x01;
+
+/// `data` payload for HlBridgeToken `ACTION_TRANSFER`:
+/// release `amount` from the system-address pool to `recipient` on HyperEVM.
+///
+/// Layout: `0x00 || abi.encode(address recipient)`.
+#[must_use]
+pub fn encode_transfer_action(recipient: Address) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + 32);
+    out.push(ACTION_TRANSFER);
+    out.extend_from_slice(&recipient.abi_encode());
+    out
+}
+
+/// `data` payload for HlBridgeToken `ACTION_INIT_TRANSFER`:
+/// bridge `amount` via `OmniBridge.initTransfer` to `recipient` with `fee`.
+///
+/// Layout: `0x01 || abi.encode(uint128 fee, string recipient, string message)`.
+#[must_use]
+pub fn encode_init_transfer_action(fee: u128, recipient: &OmniAddress, message: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + 32 * 5);
+    out.push(ACTION_INIT_TRANSFER);
+    out.extend_from_slice(&(fee, recipient.to_string(), message.to_string()).abi_encode_params());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+    use alloy::sol_types::SolValue;
+
+    #[test]
+    fn transfer_action_round_trip() {
+        let recipient = address!("00000000000000000000000000000000DeaDBeef");
+        let encoded = encode_transfer_action(recipient);
+        assert_eq!(encoded[0], ACTION_TRANSFER);
+        let decoded = Address::abi_decode(&encoded[1..]).unwrap();
+        assert_eq!(decoded, recipient);
+    }
+
+    #[test]
+    fn init_transfer_action_round_trip() {
+        let fee = 10u128;
+        let recipient: OmniAddress = "near:alice.near".parse().unwrap();
+        let message = "ref=hypercore";
+
+        let encoded = encode_init_transfer_action(fee, &recipient, message);
+        assert_eq!(encoded[0], ACTION_INIT_TRANSFER);
+
+        let (decoded_fee, decoded_recipient, decoded_message) =
+            <(u128, String, String)>::abi_decode_params(&encoded[1..]).unwrap();
+        assert_eq!(decoded_fee, fee);
+        assert_eq!(decoded_recipient, recipient.to_string());
+        assert_eq!(decoded_message, message);
+    }
+
+    #[test]
+    fn init_transfer_action_empty_message() {
+        let fee = 0u128;
+        let recipient: OmniAddress = "sol:11111111111111111111111111111111".parse().unwrap();
+        let message = "";
+
+        let encoded = encode_init_transfer_action(fee, &recipient, message);
+        let (decoded_fee, decoded_recipient, decoded_message) =
+            <(u128, String, String)>::abi_decode_params(&encoded[1..]).unwrap();
+        assert_eq!(decoded_fee, fee);
+        assert_eq!(decoded_recipient, recipient.to_string());
+        assert_eq!(decoded_message, message);
+    }
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/error.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/error.rs
@@ -1,0 +1,23 @@
+pub(crate) type Result<T> = std::result::Result<T, HyperCoreBridgeClientError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum HyperCoreBridgeClientError {
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("Invalid signatureChainId: {0}")]
+    InvalidSignatureChainId(String),
+    #[error("Encoding error: {0}")]
+    Encoding(String),
+    #[error("Signing error: {0}")]
+    Signing(String),
+    #[error("HTTP error: {0}")]
+    Http(String),
+    #[error("Hyperliquid /exchange rejected the action: {0}")]
+    ExchangeRejected(String),
+    #[error("HyperEVM RPC error: {0}")]
+    Rpc(String),
+    #[error("Timed out waiting for CoreReceived log on HyperEVM")]
+    PollTimeout,
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
@@ -1,0 +1,307 @@
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use alloy::primitives::{keccak256, Address, FixedBytes, TxHash, U256};
+use alloy::providers::{DynProvider, Provider};
+use alloy::rpc::types::Filter;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol;
+use alloy::sol_types::SolEvent;
+use serde::Serialize;
+
+use crate::action::SendToEvmWithDataAction;
+use crate::error::{HyperCoreBridgeClientError, Result};
+use crate::signing::{sign_action, ActionSignature};
+
+pub use action::{format_amount, HyperliquidNetwork};
+pub use builder::HyperCoreBridgeClientBuilder;
+pub use encoders::{
+    encode_init_transfer_action, encode_transfer_action, ACTION_INIT_TRANSFER, ACTION_TRANSFER,
+};
+
+mod action;
+mod builder;
+pub mod encoders;
+pub mod error;
+mod signing;
+
+sol! {
+    #[allow(missing_docs)]
+    interface HlBridgeToken {
+        event CoreReceived(address indexed sender, uint8 indexed action, uint256 amount, bytes data);
+    }
+}
+
+const DEFAULT_GAS_LIMIT_INIT_TRANSFER: u64 = 800_000;
+const DEFAULT_GAS_LIMIT_TRANSFER: u64 = 300_000;
+
+/// One Hyperliquid Core user, scoped to a specific network and HyperEVM RPC.
+///
+/// Builds, signs (EIP-712 user-signed action), and posts `sendToEvmWithData`
+/// actions to `/exchange`, then polls HyperEVM for the resulting `CoreReceived`
+/// log emitted by the target `HlBridgeToken` contract.
+///
+/// `Clone` is cheap: provider/signer/reqwest are all `Arc`-backed internally.
+#[derive(Clone)]
+pub struct HyperCoreBridgeClient {
+    pub(crate) network: HyperliquidNetwork,
+    pub(crate) api_url: String,
+    pub(crate) hyperevm_provider: DynProvider,
+    pub(crate) signer: PrivateKeySigner,
+    pub(crate) http_client: reqwest::Client,
+    pub(crate) signature_chain_id: String,
+    pub(crate) poll_interval: Duration,
+    pub(crate) poll_timeout: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoreReceivedLog {
+    pub sender: Address,
+    pub action: u8,
+    pub amount: U256,
+    pub data: alloy::primitives::Bytes,
+    pub transaction_hash: TxHash,
+    pub block_number: u64,
+}
+
+impl HyperCoreBridgeClient {
+    #[must_use]
+    pub fn network(&self) -> HyperliquidNetwork {
+        self.network
+    }
+
+    #[must_use]
+    pub fn signer_address(&self) -> Address {
+        self.signer.address()
+    }
+
+    pub fn default_gas_limit(action_tag: u8) -> u64 {
+        match action_tag {
+            encoders::ACTION_INIT_TRANSFER => DEFAULT_GAS_LIMIT_INIT_TRANSFER,
+            _ => DEFAULT_GAS_LIMIT_TRANSFER,
+        }
+    }
+
+    /// Builds, signs, and posts a `sendToEvmWithData` action targeting `hl_bridge_token`
+    /// on HyperEVM, then polls for the resulting `CoreReceived` log.
+    ///
+    /// Returns the HyperEVM `TxHash` that emitted the log. The `data` payload is
+    /// expected to already encode `tag || abi.encoded payload` (use the encoders
+    /// in this crate).
+    pub async fn send_to_evm_with_data(
+        &self,
+        token: String,
+        amount: String,
+        hl_bridge_token: Address,
+        data: Vec<u8>,
+        gas_limit: Option<u64>,
+    ) -> Result<TxHash> {
+        self.send_to_evm_with_data_detailed(token, amount, hl_bridge_token, data, gas_limit)
+            .await
+            .map(|log| log.transaction_hash)
+    }
+
+    /// Detailed variant returning the full `CoreReceivedLog` (sender, action
+    /// tag, amount, data, tx hash, block). The single source of truth for
+    /// action construction; [`send_to_evm_with_data`] is a thin wrapper.
+    #[tracing::instrument(skip_all, name = "HYPERCORE SEND TO EVM WITH DATA")]
+    pub async fn send_to_evm_with_data_detailed(
+        &self,
+        token: String,
+        amount: String,
+        hl_bridge_token: Address,
+        data: Vec<u8>,
+        gas_limit: Option<u64>,
+    ) -> Result<CoreReceivedLog> {
+        let action_tag = data.first().copied().ok_or_else(|| {
+            HyperCoreBridgeClientError::InvalidArgument(
+                "action `data` must be non-empty (at least the action tag)".to_string(),
+            )
+        })?;
+        let nonce = current_ms_nonce();
+        let action = SendToEvmWithDataAction {
+            action_type: "sendToEvmWithData",
+            hyperliquid_chain: self.network.hyperliquid_chain(),
+            signature_chain_id: self.signature_chain_id.clone(),
+            token,
+            amount,
+            source_dex: "spot".to_string(),
+            destination_recipient: format!("0x{}", hex::encode(hl_bridge_token.as_slice())),
+            address_encoding: "hex".to_string(),
+            destination_chain_id: self.network.hyperevm_chain_id(),
+            gas_limit: gas_limit.unwrap_or_else(|| Self::default_gas_limit(action_tag)),
+            data: format!("0x{}", hex::encode(&data)),
+            nonce,
+        };
+
+        let signature = sign_action(&self.signer, &action)?;
+        self.post_action(&action, &signature, nonce).await?;
+        self.poll_core_received(hl_bridge_token, &data).await
+    }
+
+    async fn post_action(
+        &self,
+        action: &SendToEvmWithDataAction,
+        signature: &ActionSignature,
+        nonce: u64,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct Envelope<'a> {
+            action: &'a SendToEvmWithDataAction,
+            nonce: u64,
+            signature: &'a ActionSignature,
+        }
+
+        let body = Envelope {
+            action,
+            nonce,
+            signature,
+        };
+
+        let url = format!("{}/exchange", self.api_url);
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| HyperCoreBridgeClientError::Http(e.to_string()))?;
+
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .map_err(|e| HyperCoreBridgeClientError::Http(e.to_string()))?;
+
+        if !status.is_success() {
+            return Err(HyperCoreBridgeClientError::ExchangeRejected(format!(
+                "HTTP {status}: {text}"
+            )));
+        }
+
+        let parsed: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
+            HyperCoreBridgeClientError::ExchangeRejected(format!(
+                "could not parse /exchange response as JSON ({e}): {text}"
+            ))
+        })?;
+
+        match parsed.get("status").and_then(|s| s.as_str()) {
+            Some("ok") => {
+                tracing::info!(?nonce, "Hyperliquid /exchange accepted sendToEvmWithData");
+                Ok(())
+            }
+            Some("err") => {
+                let msg = parsed
+                    .get("response")
+                    .and_then(|r| r.as_str())
+                    .unwrap_or(text.as_str())
+                    .to_string();
+                Err(HyperCoreBridgeClientError::ExchangeRejected(msg))
+            }
+            _ => Err(HyperCoreBridgeClientError::ExchangeRejected(format!(
+                "unexpected /exchange response shape: {text}"
+            ))),
+        }
+    }
+
+    /// Polls HyperEVM for the `CoreReceived` log emitted by our `sendToEvmWithData`
+    /// action. Filter is `address + topic0 + topic1=signer`. Disambiguation
+    /// across concurrent calls from the same signer relies on `expected_data`
+    /// matching `log.data`: the encoded `tag || abi.encode(payload)` bytes are
+    /// effectively a unique identifier per call *unless* the caller fires two
+    /// calls with identical parameters in flight at once — in that case the
+    /// protocol can't disambiguate them either.
+    async fn poll_core_received(
+        &self,
+        hl_bridge_token: Address,
+        expected_data: &[u8],
+    ) -> Result<CoreReceivedLog> {
+        let topic0 = keccak256(HlBridgeToken::CoreReceived::SIGNATURE.as_bytes());
+        let signer_address = self.signer.address();
+        let mut topic1 = [0u8; 32];
+        topic1[12..].copy_from_slice(signer_address.as_slice());
+        let topic1 = FixedBytes::<32>::from(topic1);
+
+        let head_at_start = self
+            .hyperevm_provider
+            .get_block_number()
+            .await
+            .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
+        // Look back ~10 blocks in case the system tx already landed during the
+        // POST round-trip; HyperEVM small blocks are 1s.
+        let mut from_block = head_at_start.saturating_sub(10);
+
+        let start = Instant::now();
+        loop {
+            tokio::time::sleep(self.poll_interval).await;
+            if start.elapsed() > self.poll_timeout {
+                return Err(HyperCoreBridgeClientError::PollTimeout);
+            }
+
+            let head = self
+                .hyperevm_provider
+                .get_block_number()
+                .await
+                .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
+            if head < from_block {
+                continue;
+            }
+
+            let filter = Filter::new()
+                .address(hl_bridge_token)
+                .event_signature(topic0)
+                .topic1(topic1)
+                .from_block(from_block)
+                .to_block(head);
+
+            let logs = self
+                .hyperevm_provider
+                .get_logs(&filter)
+                .await
+                .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
+
+            for log in logs {
+                let inner = log.inner.clone();
+                let decoded = HlBridgeToken::CoreReceived::decode_log(&inner).map_err(|e| {
+                    HyperCoreBridgeClientError::Rpc(format!(
+                        "failed to decode CoreReceived log: {e}"
+                    ))
+                })?;
+                if decoded.data.data.as_ref() != expected_data {
+                    continue;
+                }
+                let tx_hash = log.transaction_hash.ok_or_else(|| {
+                    HyperCoreBridgeClientError::Rpc(
+                        "CoreReceived log missing transaction_hash".to_string(),
+                    )
+                })?;
+                let block_number = log.block_number.ok_or_else(|| {
+                    HyperCoreBridgeClientError::Rpc(
+                        "CoreReceived log missing block_number".to_string(),
+                    )
+                })?;
+                let HlBridgeToken::CoreReceived {
+                    sender,
+                    action,
+                    amount,
+                    data,
+                } = decoded.data;
+                return Ok(CoreReceivedLog {
+                    sender,
+                    action,
+                    amount,
+                    data,
+                    transaction_hash: tx_hash,
+                    block_number,
+                });
+            }
+
+            from_block = head.saturating_add(1);
+        }
+    }
+}
+
+fn current_ms_nonce() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
@@ -221,81 +221,79 @@ impl HyperCoreBridgeClient {
         topic1[12..].copy_from_slice(signer_address.as_slice());
         let topic1 = FixedBytes::<32>::from(topic1);
 
-        let head_at_start = self
+        let mut head = self
             .hyperevm_provider
             .get_block_number()
             .await
             .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
         // Look back ~10 blocks in case the system tx already landed during the
         // POST round-trip; HyperEVM small blocks are 1s.
-        let mut from_block = head_at_start.saturating_sub(10);
+        let mut from_block = head.saturating_sub(10);
 
         let start = Instant::now();
         loop {
-            tokio::time::sleep(self.poll_interval).await;
-            if start.elapsed() > self.poll_timeout {
-                return Err(HyperCoreBridgeClientError::PollTimeout);
+            if head >= from_block {
+                let filter = Filter::new()
+                    .address(hl_bridge_token)
+                    .event_signature(topic0)
+                    .topic1(topic1)
+                    .from_block(from_block)
+                    .to_block(head);
+
+                let logs = self
+                    .hyperevm_provider
+                    .get_logs(&filter)
+                    .await
+                    .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
+
+                for log in logs {
+                    let inner = log.inner.clone();
+                    let decoded = HlBridgeToken::CoreReceived::decode_log(&inner).map_err(|e| {
+                        HyperCoreBridgeClientError::Rpc(format!(
+                            "failed to decode CoreReceived log: {e}"
+                        ))
+                    })?;
+                    if decoded.data.data.as_ref() != expected_data {
+                        continue;
+                    }
+                    let tx_hash = log.transaction_hash.ok_or_else(|| {
+                        HyperCoreBridgeClientError::Rpc(
+                            "CoreReceived log missing transaction_hash".to_string(),
+                        )
+                    })?;
+                    let block_number = log.block_number.ok_or_else(|| {
+                        HyperCoreBridgeClientError::Rpc(
+                            "CoreReceived log missing block_number".to_string(),
+                        )
+                    })?;
+                    let HlBridgeToken::CoreReceived {
+                        sender,
+                        action,
+                        amount,
+                        data,
+                    } = decoded.data;
+                    return Ok(CoreReceivedLog {
+                        sender,
+                        action,
+                        amount,
+                        data,
+                        transaction_hash: tx_hash,
+                        block_number,
+                    });
+                }
+
+                from_block = head.saturating_add(1);
             }
 
-            let head = self
+            if start.elapsed() >= self.poll_timeout {
+                return Err(HyperCoreBridgeClientError::PollTimeout);
+            }
+            tokio::time::sleep(self.poll_interval).await;
+            head = self
                 .hyperevm_provider
                 .get_block_number()
                 .await
                 .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
-            if head < from_block {
-                continue;
-            }
-
-            let filter = Filter::new()
-                .address(hl_bridge_token)
-                .event_signature(topic0)
-                .topic1(topic1)
-                .from_block(from_block)
-                .to_block(head);
-
-            let logs = self
-                .hyperevm_provider
-                .get_logs(&filter)
-                .await
-                .map_err(|e| HyperCoreBridgeClientError::Rpc(e.to_string()))?;
-
-            for log in logs {
-                let inner = log.inner.clone();
-                let decoded = HlBridgeToken::CoreReceived::decode_log(&inner).map_err(|e| {
-                    HyperCoreBridgeClientError::Rpc(format!(
-                        "failed to decode CoreReceived log: {e}"
-                    ))
-                })?;
-                if decoded.data.data.as_ref() != expected_data {
-                    continue;
-                }
-                let tx_hash = log.transaction_hash.ok_or_else(|| {
-                    HyperCoreBridgeClientError::Rpc(
-                        "CoreReceived log missing transaction_hash".to_string(),
-                    )
-                })?;
-                let block_number = log.block_number.ok_or_else(|| {
-                    HyperCoreBridgeClientError::Rpc(
-                        "CoreReceived log missing block_number".to_string(),
-                    )
-                })?;
-                let HlBridgeToken::CoreReceived {
-                    sender,
-                    action,
-                    amount,
-                    data,
-                } = decoded.data;
-                return Ok(CoreReceivedLog {
-                    sender,
-                    action,
-                    amount,
-                    data,
-                    transaction_hash: tx_hash,
-                    block_number,
-                });
-            }
-
-            from_block = head.saturating_add(1);
         }
     }
 }

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/hypercore_bridge_client.rs
@@ -17,11 +17,13 @@ pub use builder::HyperCoreBridgeClientBuilder;
 pub use encoders::{
     encode_init_transfer_action, encode_transfer_action, ACTION_INIT_TRANSFER, ACTION_TRANSFER,
 };
+pub use info::{EvmContract, ResolvedSpotToken, SpotMetaResponse, SpotMetaToken};
 
 mod action;
 mod builder;
 pub mod encoders;
 pub mod error;
+mod info;
 mod signing;
 
 sol! {
@@ -79,6 +81,37 @@ impl HyperCoreBridgeClient {
             encoders::ACTION_INIT_TRANSFER => DEFAULT_GAS_LIMIT_INIT_TRANSFER,
             _ => DEFAULT_GAS_LIMIT_TRANSFER,
         }
+    }
+
+    /// Resolves a Hyperliquid spot identifier (`"NAME:0x<32hex>"`) into the
+    /// linked HyperEVM ERC20 address and the bridge token's decimals by
+    /// querying `POST /info {"type":"spotMeta"}`.
+    ///
+    /// `decimals = weiDecimals + evm_extra_wei_decimals` per Hyperliquid's
+    /// spot↔EVM linking convention. Errors if the token isn't in the spotMeta
+    /// universe or has no `evmContract` entry (not linked).
+    pub async fn resolve_spot_token(&self, token: &str) -> Result<info::ResolvedSpotToken> {
+        let (name, token_id) = info::parse_token_identifier(token)?;
+        let url = format!("{}/info", self.api_url);
+        let response = self
+            .http_client
+            .post(&url)
+            .json(&serde_json::json!({"type": "spotMeta"}))
+            .send()
+            .await
+            .map_err(|e| HyperCoreBridgeClientError::Http(e.to_string()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(HyperCoreBridgeClientError::Http(format!(
+                "spotMeta HTTP {status}: {body}"
+            )));
+        }
+        let meta: info::SpotMetaResponse = response
+            .json()
+            .await
+            .map_err(|e| HyperCoreBridgeClientError::Http(format!("invalid spotMeta JSON: {e}")))?;
+        info::pick_resolved_token(&meta, name, &token_id)
     }
 
     /// Builds, signs, and posts a `sendToEvmWithData` action targeting `hl_bridge_token`

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/info.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/info.rs
@@ -1,0 +1,233 @@
+use alloy::primitives::Address;
+use serde::Deserialize;
+
+use crate::error::{HyperCoreBridgeClientError, Result};
+
+/// Subset of `POST /info {"type":"spotMeta"}` we care about.
+///
+/// Hyperliquid's response has many more fields (universe, fullName, etc.);
+/// the unused ones are dropped via `#[serde(default)]` and field skipping.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpotMetaResponse {
+    pub tokens: Vec<SpotMetaToken>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpotMetaToken {
+    pub name: String,
+    #[serde(rename = "tokenId")]
+    pub token_id: String,
+    #[serde(rename = "weiDecimals")]
+    pub wei_decimals: i16,
+    /// `None` for tokens that aren't linked to a HyperEVM ERC20.
+    #[serde(rename = "evmContract")]
+    pub evm_contract: Option<EvmContract>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvmContract {
+    pub address: Address,
+    /// Signed offset; final ERC20 decimals = `weiDecimals + evm_extra_wei_decimals`.
+    /// e.g. USDC: weiDecimals=8, evm_extra_wei_decimals=-2 → ERC20 has 6 decimals.
+    pub evm_extra_wei_decimals: i16,
+}
+
+/// Resolved metadata for a single Hyperliquid spot token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedSpotToken {
+    /// HlBridgeToken (or generic linked ERC20) address on HyperEVM.
+    pub hl_bridge_token: Address,
+    /// Bridge ERC20's decimals (used to format wire amounts).
+    pub decimals: u8,
+}
+
+/// Parses `"NAME:0x<32-hex>"` (or `"NAME:<32-hex>"`) into `(name, normalized tokenId)`.
+pub(crate) fn parse_token_identifier(token: &str) -> Result<(&str, String)> {
+    let (name, token_id) = token.split_once(':').ok_or_else(|| {
+        HyperCoreBridgeClientError::InvalidArgument(format!(
+            "token must be in form `NAME:0x<32hex>`, got `{token}`"
+        ))
+    })?;
+    let stripped = token_id.strip_prefix("0x").unwrap_or(token_id);
+    Ok((name, format!("0x{}", stripped.to_lowercase())))
+}
+
+/// Locate a token in a `SpotMetaResponse` by name+tokenId and convert its
+/// linked EVM contract entry into a `ResolvedSpotToken`.
+pub(crate) fn pick_resolved_token(
+    meta: &SpotMetaResponse,
+    name: &str,
+    token_id: &str,
+) -> Result<ResolvedSpotToken> {
+    let token = meta
+        .tokens
+        .iter()
+        .find(|t| t.name == name && t.token_id.eq_ignore_ascii_case(token_id))
+        .ok_or_else(|| {
+            HyperCoreBridgeClientError::InvalidArgument(format!(
+                "spotMeta has no token matching `{name}:{token_id}`"
+            ))
+        })?;
+
+    let evm = token.evm_contract.as_ref().ok_or_else(|| {
+        HyperCoreBridgeClientError::InvalidArgument(format!(
+            "token `{name}:{token_id}` is not linked to a HyperEVM ERC20"
+        ))
+    })?;
+
+    let decimals_i32 = i32::from(token.wei_decimals) + i32::from(evm.evm_extra_wei_decimals);
+    let decimals = u8::try_from(decimals_i32).map_err(|_| {
+        HyperCoreBridgeClientError::Encoding(format!(
+            "resolved decimals {decimals_i32} for `{name}:{token_id}` is out of u8 range"
+        ))
+    })?;
+
+    Ok(ResolvedSpotToken {
+        hl_bridge_token: evm.address,
+        decimals,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "universe": [],
+        "tokens": [
+            {
+                "name": "USDC",
+                "szDecimals": 8,
+                "weiDecimals": 8,
+                "index": 0,
+                "tokenId": "0xeb62eee3685fc4c43992febcd9e75443",
+                "isCanonical": true,
+                "evmContract": {
+                    "address": "0x0b80659a4076e9e93c7dbe0f10675a16a3e5c206",
+                    "evm_extra_wei_decimals": -2
+                },
+                "fullName": null
+            },
+            {
+                "name": "PURR",
+                "szDecimals": 0,
+                "weiDecimals": 5,
+                "index": 1,
+                "tokenId": "0xc4bf3f870c0e9465323c0b6ed28096c2",
+                "isCanonical": true,
+                "evmContract": null,
+                "fullName": null
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn parses_real_spot_meta_subset() {
+        let meta: SpotMetaResponse = serde_json::from_str(SAMPLE).unwrap();
+        assert_eq!(meta.tokens.len(), 2);
+        assert_eq!(meta.tokens[0].name, "USDC");
+        let usdc_evm = meta.tokens[0].evm_contract.as_ref().unwrap();
+        assert_eq!(
+            usdc_evm.address,
+            "0x0b80659a4076e9e93c7dbe0f10675a16a3e5c206"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(usdc_evm.evm_extra_wei_decimals, -2);
+        assert!(meta.tokens[1].evm_contract.is_none());
+    }
+
+    #[test]
+    fn picks_token_and_computes_decimals() {
+        let meta: SpotMetaResponse = serde_json::from_str(SAMPLE).unwrap();
+        let resolved =
+            pick_resolved_token(&meta, "USDC", "0xeb62eee3685fc4c43992febcd9e75443").unwrap();
+        assert_eq!(resolved.decimals, 6); // 8 + (-2)
+        assert_eq!(
+            resolved.hl_bridge_token,
+            "0x0b80659a4076e9e93c7dbe0f10675a16a3e5c206"
+                .parse::<Address>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn picks_token_id_case_insensitive() {
+        let meta: SpotMetaResponse = serde_json::from_str(SAMPLE).unwrap();
+        let resolved =
+            pick_resolved_token(&meta, "USDC", "0xEB62EEE3685FC4C43992FEBCD9E75443").unwrap();
+        assert_eq!(resolved.decimals, 6);
+    }
+
+    #[test]
+    fn rejects_unlinked_token() {
+        let meta: SpotMetaResponse = serde_json::from_str(SAMPLE).unwrap();
+        let err =
+            pick_resolved_token(&meta, "PURR", "0xc4bf3f870c0e9465323c0b6ed28096c2").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not linked"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_token() {
+        let meta: SpotMetaResponse = serde_json::from_str(SAMPLE).unwrap();
+        let err = pick_resolved_token(&meta, "DOES_NOT_EXIST", "0xdeadbeef").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no token matching"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_token_identifier_normalizes() {
+        let (name, id) = parse_token_identifier("USDC:0xEB62EEE3").unwrap();
+        assert_eq!(name, "USDC");
+        assert_eq!(id, "0xeb62eee3");
+
+        let (name, id) = parse_token_identifier("PURR:c4bf").unwrap();
+        assert_eq!(name, "PURR");
+        assert_eq!(id, "0xc4bf");
+
+        assert!(parse_token_identifier("malformed").is_err());
+    }
+
+    /// End-to-end check against the live testnet `/info` endpoint:
+    /// confirms the real response still parses cleanly into our subset of
+    /// fields and that USDC's evmContract / decimal math matches expectations.
+    ///
+    /// Ignored by default. Run with:
+    ///   `cargo test -p hypercore-bridge-client info::tests::testnet_spotmeta_parses -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "hits Hyperliquid testnet /info"]
+    async fn testnet_spotmeta_parses() {
+        let response = reqwest::Client::new()
+            .post("https://api.hyperliquid-testnet.xyz/info")
+            .json(&serde_json::json!({"type": "spotMeta"}))
+            .send()
+            .await
+            .expect("POST failed");
+        assert!(
+            response.status().is_success(),
+            "status: {}",
+            response.status()
+        );
+        let meta: SpotMetaResponse = response.json().await.expect("invalid spotMeta JSON");
+        assert!(!meta.tokens.is_empty(), "tokens array empty");
+
+        // USDC is canonical and stable across testnet redeploys — use it as a
+        // structural fixture point. Skip the assertion if the testnet topology
+        // ever changes (don't want this to break on legitimate evolution).
+        let usdc = meta.tokens.iter().find(|t| t.name == "USDC");
+        if let Some(usdc) = usdc {
+            println!("USDC: {usdc:?}");
+            if let Some(evm) = &usdc.evm_contract {
+                let resolved = pick_resolved_token(&meta, "USDC", &usdc.token_id).unwrap();
+                println!(
+                    "Resolved: erc20={:?}, decimals={} (weiDecimals={} + extra={})",
+                    resolved.hl_bridge_token,
+                    resolved.decimals,
+                    usdc.wei_decimals,
+                    evm.evm_extra_wei_decimals,
+                );
+            }
+        }
+    }
+}

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/signing.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/signing.rs
@@ -9,11 +9,16 @@ use crate::error::{HyperCoreBridgeClientError, Result};
 
 /// EIP-712 type string for `HyperliquidTransaction:SendToEvmWithData`.
 ///
-/// **Inferred** from the JSON shape (GitBook docs llms-full.txt:5837) and the
-/// user-signed-action convention in hyperliquid-python-sdk:signing.py:88-119.
-/// Hyperliquid's own SDKs do not implement this action; until we validate
-/// signer recovery on testnet, treat field order and integer widths as the
-/// primary suspects if the L1 rejects with a signature/user-not-found error.
+/// Originally inferred from the GitBook docs (`llms-full.txt:5837`) and the
+/// user-signed-action convention in hyperliquid-python-sdk:signing.py:88-119,
+/// because neither official SDK implements `sendToEvmWithData`.
+///
+/// **Validated against Hyperliquid testnet `/exchange`**: signing with a
+/// random key and posting yields `"Must deposit before performing actions.
+/// User: <our-address>"`, where the embedded address matches the signer.
+/// That proves the L1 recovers the correct address from our digest —
+/// i.e. field order, integer widths, and which fields are signed are all
+/// correct. See `testnet_l1_recovers_our_address` below.
 const SEND_TO_EVM_WITH_DATA_TYPE: &str = "HyperliquidTransaction:SendToEvmWithData(string hyperliquidChain,string token,string amount,string sourceDex,string destinationRecipient,string addressEncoding,uint32 destinationChainId,uint64 gasLimit,bytes data,uint64 nonce)";
 
 const EIP712_DOMAIN_TYPE: &str =
@@ -162,6 +167,102 @@ mod tests {
         let mut variant = sample_action();
         variant.data = "0x01ff".to_string();
         assert_ne!(compute_struct_hash(&variant).unwrap(), base);
+    }
+
+    /// Smoke-tests the EIP-712 type list against the real Hyperliquid testnet
+    /// `/exchange` endpoint.
+    ///
+    /// We sign with a fresh random key whose address has no HyperCore account,
+    /// then POST the action. The L1 recomputes the digest, recovers `(r,s,v)`
+    /// against it, and rejects because the recovered address has no Core
+    /// balance. Crucially the error embeds the recovered address — when that
+    /// matches the wallet we signed with, our type list / field order /
+    /// integer widths are all correct.
+    ///
+    /// Don't use a deterministic well-known key (Anvil `0xac09…`): someone has
+    /// configured that address as a multi-sig account on testnet, which
+    /// triggers a different (less informative) `"Multi-sig required"` error.
+    ///
+    /// Ignored by default because it hits the network. Run with:
+    ///   `cargo test -p hypercore-bridge-client testnet -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "hits Hyperliquid testnet /exchange"]
+    async fn testnet_l1_recovers_our_address() {
+        use crate::encoders::encode_transfer_action;
+
+        // Fresh random key — 1 in 2^160 chance of colliding with a real
+        // account on testnet. If the response is still "Multi-sig required"
+        // with a brand-new address, that tells us `sendToEvmWithData` itself
+        // requires multi-sig (not an artifact of someone else's testing).
+        let signer = PrivateKeySigner::random();
+        let our_address = signer.address();
+        println!("\n=== Our signer address: {our_address:?} ===\n");
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+
+        // ACTION_TRANSFER with our own address as the recipient (pool release).
+        // Doesn't matter that the HlBridgeToken at destinationRecipient doesn't
+        // exist — we just want the L1 to evaluate our signature.
+        let data_bytes = encode_transfer_action(our_address);
+        let data_hex = format!("0x{}", hex::encode(&data_bytes));
+
+        let action = SendToEvmWithDataAction {
+            action_type: "sendToEvmWithData",
+            hyperliquid_chain: "Testnet",
+            signature_chain_id: "0x66eee".to_string(),
+            token: "PURR:0xc4bf3f870c0e9465323c0b6ed28096c2".to_string(),
+            amount: "0.01".to_string(),
+            source_dex: "spot".to_string(),
+            destination_recipient: format!("{our_address:?}").to_lowercase(),
+            address_encoding: "hex".to_string(),
+            destination_chain_id: 998,
+            gas_limit: 800_000,
+            data: data_hex,
+            nonce,
+        };
+        println!("Action: {}", serde_json::to_string_pretty(&action).unwrap());
+
+        let signature = sign_action(&signer, &action).unwrap();
+        println!("Signature: {signature:?}\n");
+
+        #[derive(serde::Serialize)]
+        struct Envelope<'a> {
+            action: &'a SendToEvmWithDataAction,
+            nonce: u64,
+            signature: &'a ActionSignature,
+        }
+        let envelope = Envelope {
+            action: &action,
+            nonce,
+            signature: &signature,
+        };
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap();
+        let response = client
+            .post("https://api.hyperliquid-testnet.xyz/exchange")
+            .json(&envelope)
+            .send()
+            .await
+            .expect("POST failed");
+
+        let status = response.status();
+        let body = response.text().await.unwrap();
+        println!("=== HTTP {status} ===");
+        println!("Body: {body}");
+
+        let our_addr_lower = format!("{our_address:?}").to_lowercase();
+        assert!(
+            body.to_lowercase().contains(&our_addr_lower),
+            "Hyperliquid response did not reference our signing address {our_addr_lower}.\n\
+             This means the L1 recovered a different signer from our digest — \
+             EIP-712 type list or field order is wrong.\nFull body: {body}"
+        );
     }
 
     #[test]

--- a/bridge-sdk/bridge-clients/hypercore-bridge-client/src/signing.rs
+++ b/bridge-sdk/bridge-clients/hypercore-bridge-client/src/signing.rs
@@ -1,0 +1,195 @@
+use alloy::primitives::{keccak256, Address, B256, U256};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::SignerSync;
+use alloy::sol_types::SolValue;
+use serde::Serialize;
+
+use crate::action::SendToEvmWithDataAction;
+use crate::error::{HyperCoreBridgeClientError, Result};
+
+/// EIP-712 type string for `HyperliquidTransaction:SendToEvmWithData`.
+///
+/// **Inferred** from the JSON shape (GitBook docs llms-full.txt:5837) and the
+/// user-signed-action convention in hyperliquid-python-sdk:signing.py:88-119.
+/// Hyperliquid's own SDKs do not implement this action; until we validate
+/// signer recovery on testnet, treat field order and integer widths as the
+/// primary suspects if the L1 rejects with a signature/user-not-found error.
+const SEND_TO_EVM_WITH_DATA_TYPE: &str = "HyperliquidTransaction:SendToEvmWithData(string hyperliquidChain,string token,string amount,string sourceDex,string destinationRecipient,string addressEncoding,uint32 destinationChainId,uint64 gasLimit,bytes data,uint64 nonce)";
+
+const EIP712_DOMAIN_TYPE: &str =
+    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+const HL_DOMAIN_NAME: &str = "HyperliquidSignTransaction";
+const HL_DOMAIN_VERSION: &str = "1";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ActionSignature {
+    pub r: String,
+    pub s: String,
+    pub v: u8,
+}
+
+pub fn sign_action(
+    signer: &PrivateKeySigner,
+    action: &SendToEvmWithDataAction,
+) -> Result<ActionSignature> {
+    let chain_id = parse_signature_chain_id(&action.signature_chain_id)?;
+    let domain_separator = compute_domain_separator(chain_id);
+    let struct_hash = compute_struct_hash(action)?;
+
+    let mut digest_input = Vec::with_capacity(2 + 32 + 32);
+    digest_input.push(0x19);
+    digest_input.push(0x01);
+    digest_input.extend_from_slice(domain_separator.as_slice());
+    digest_input.extend_from_slice(struct_hash.as_slice());
+    let digest = keccak256(&digest_input);
+
+    let signature = signer
+        .sign_hash_sync(&digest)
+        .map_err(|e| HyperCoreBridgeClientError::Signing(e.to_string()))?;
+
+    let r = signature.r();
+    let s = signature.s();
+    let v_parity: u8 = u8::from(signature.v());
+    let v = 27u8 + v_parity;
+
+    Ok(ActionSignature {
+        r: format!("0x{r:064x}"),
+        s: format!("0x{s:064x}"),
+        v,
+    })
+}
+
+fn parse_signature_chain_id(s: &str) -> Result<u64> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    u64::from_str_radix(stripped, 16)
+        .map_err(|_| HyperCoreBridgeClientError::InvalidSignatureChainId(s.to_string()))
+}
+
+fn compute_domain_separator(chain_id: u64) -> B256 {
+    let type_hash = keccak256(EIP712_DOMAIN_TYPE.as_bytes());
+    let name_hash = keccak256(HL_DOMAIN_NAME.as_bytes());
+    let version_hash = keccak256(HL_DOMAIN_VERSION.as_bytes());
+    let verifying_contract = Address::ZERO;
+
+    let encoded = (
+        type_hash,
+        name_hash,
+        version_hash,
+        U256::from(chain_id),
+        verifying_contract,
+    )
+        .abi_encode_params();
+
+    keccak256(encoded)
+}
+
+fn compute_struct_hash(action: &SendToEvmWithDataAction) -> Result<B256> {
+    let type_hash = keccak256(SEND_TO_EVM_WITH_DATA_TYPE.as_bytes());
+
+    let data_hex = action.data.strip_prefix("0x").unwrap_or(&action.data);
+    let data_bytes = hex::decode(data_hex).map_err(|e| {
+        HyperCoreBridgeClientError::Encoding(format!("`data` field is not valid hex: {e}"))
+    })?;
+
+    let encoded = (
+        type_hash,
+        keccak256(action.hyperliquid_chain.as_bytes()),
+        keccak256(action.token.as_bytes()),
+        keccak256(action.amount.as_bytes()),
+        keccak256(action.source_dex.as_bytes()),
+        keccak256(action.destination_recipient.as_bytes()),
+        keccak256(action.address_encoding.as_bytes()),
+        U256::from(action.destination_chain_id),
+        U256::from(action.gas_limit),
+        keccak256(&data_bytes),
+        U256::from(action.nonce),
+    )
+        .abi_encode_params();
+
+    Ok(keccak256(encoded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_action() -> SendToEvmWithDataAction {
+        SendToEvmWithDataAction {
+            action_type: "sendToEvmWithData",
+            hyperliquid_chain: "Testnet",
+            signature_chain_id: "0x66eee".to_string(),
+            token: "PURR:0xc4bf3f870c0e9465323c0b6ed28096c2".to_string(),
+            amount: "0.01".to_string(),
+            source_dex: "spot".to_string(),
+            destination_recipient: "0x000000000000000000000000000000000000dead".to_string(),
+            address_encoding: "hex".to_string(),
+            destination_chain_id: 998,
+            gas_limit: 800_000,
+            data: "0x0100".to_string(),
+            nonce: 1_716_531_066_415,
+        }
+    }
+
+    #[test]
+    fn parses_signature_chain_id() {
+        assert_eq!(parse_signature_chain_id("0x66eee").unwrap(), 421_614);
+        assert_eq!(parse_signature_chain_id("0xa4b1").unwrap(), 42_161);
+        assert_eq!(parse_signature_chain_id("a4b1").unwrap(), 42_161);
+        assert!(parse_signature_chain_id("not-hex").is_err());
+    }
+
+    #[test]
+    fn domain_separator_is_deterministic() {
+        let a = compute_domain_separator(421_614);
+        let b = compute_domain_separator(421_614);
+        assert_eq!(a, b);
+        let c = compute_domain_separator(42_161);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn struct_hash_changes_with_each_field() {
+        let base = compute_struct_hash(&sample_action()).unwrap();
+
+        let mut variant = sample_action();
+        variant.amount = "0.02".to_string();
+        assert_ne!(compute_struct_hash(&variant).unwrap(), base);
+
+        let mut variant = sample_action();
+        variant.gas_limit = 900_000;
+        assert_ne!(compute_struct_hash(&variant).unwrap(), base);
+
+        let mut variant = sample_action();
+        variant.data = "0x01ff".to_string();
+        assert_ne!(compute_struct_hash(&variant).unwrap(), base);
+    }
+
+    #[test]
+    fn sign_action_recovers_signer() {
+        let signer: PrivateKeySigner =
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+                .parse()
+                .unwrap();
+        let expected = signer.address();
+        let action = sample_action();
+        let sig = sign_action(&signer, &action).unwrap();
+
+        let r = U256::from_str_radix(sig.r.trim_start_matches("0x"), 16).unwrap();
+        let s = U256::from_str_radix(sig.s.trim_start_matches("0x"), 16).unwrap();
+        let parity = sig.v == 28;
+        let recovered_sig = alloy::primitives::Signature::new(r, s, parity);
+
+        let chain_id = parse_signature_chain_id(&action.signature_chain_id).unwrap();
+        let domain_separator = compute_domain_separator(chain_id);
+        let struct_hash = compute_struct_hash(&action).unwrap();
+        let mut digest_input = Vec::with_capacity(66);
+        digest_input.push(0x19);
+        digest_input.push(0x01);
+        digest_input.extend_from_slice(domain_separator.as_slice());
+        digest_input.extend_from_slice(struct_hash.as_slice());
+        let digest = keccak256(&digest_input);
+
+        let recovered = recovered_sig.recover_address_from_prehash(&digest).unwrap();
+        assert_eq!(recovered, expected);
+    }
+}

--- a/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
+++ b/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
@@ -17,3 +17,4 @@ solana-bridge-client = { path = "../../bridge-clients/solana-bridge-client" }
 utxo-bridge-client = { path = "../../bridge-clients/utxo-bridge-client" }
 evm-bridge-client = { path = "../../bridge-clients/evm-bridge-client" }
 starknet-bridge-client = { path = "../../bridge-clients/starknet-bridge-client" }
+hypercore-bridge-client = { path = "../../bridge-clients/hypercore-bridge-client" }

--- a/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
+++ b/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-connector-common"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/bridge-connector-common/src/result.rs
+++ b/bridge-sdk/connectors/bridge-connector-common/src/result.rs
@@ -4,6 +4,7 @@ use alloy::{
 };
 use eth_proof::{EthClientError, EthProofError};
 use evm_bridge_client::error::EvmBridgeClientError;
+use hypercore_bridge_client::error::HyperCoreBridgeClientError;
 use near_rpc_client::NearRpcError;
 use solana_bridge_client::error::SolanaBridgeClientError;
 use solana_client::client_error::ClientError;
@@ -67,6 +68,12 @@ pub enum BridgeSdkError {
     StarknetOtherError(String),
     #[error("Transaction has not reached the required MPC finality")]
     MpcFinalityNotReached,
+    #[error("Error working with HyperCore: {0}")]
+    HyperCoreError(String),
+    #[error("Hyperliquid /exchange rejected the action: {0}")]
+    HyperCoreActionRejected(String),
+    #[error("Timed out waiting for CoreReceived log on HyperEVM")]
+    HyperCorePollTimeout,
 }
 
 impl From<SolanaBridgeClientError> for BridgeSdkError {
@@ -129,6 +136,22 @@ impl From<StarknetBridgeClientError> for BridgeSdkError {
             StarknetBridgeClientError::InvalidArgument(e) => Self::InvalidArgument(e),
             StarknetBridgeClientError::TransactionError(e) => Self::StarknetOtherError(e),
             StarknetBridgeClientError::MpcFinalityNotReached => Self::MpcFinalityNotReached,
+        }
+    }
+}
+
+impl From<HyperCoreBridgeClientError> for BridgeSdkError {
+    fn from(error: HyperCoreBridgeClientError) -> Self {
+        match error {
+            HyperCoreBridgeClientError::ConfigError(e) => Self::ConfigError(e),
+            HyperCoreBridgeClientError::InvalidArgument(e)
+            | HyperCoreBridgeClientError::InvalidSignatureChainId(e) => Self::InvalidArgument(e),
+            HyperCoreBridgeClientError::Encoding(e)
+            | HyperCoreBridgeClientError::Signing(e)
+            | HyperCoreBridgeClientError::Http(e)
+            | HyperCoreBridgeClientError::Rpc(e) => Self::HyperCoreError(e),
+            HyperCoreBridgeClientError::ExchangeRejected(e) => Self::HyperCoreActionRejected(e),
+            HyperCoreBridgeClientError::PollTimeout => Self::HyperCorePollTimeout,
         }
     }
 }

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -47,6 +47,7 @@ solana-bridge-client = { path = "../../bridge-clients/solana-bridge-client" }
 wormhole-bridge-client = { path = "../../bridge-clients/wormhole-bridge-client" }
 utxo-bridge-client = { path = "../../bridge-clients/utxo-bridge-client" }
 starknet-bridge-client = { path = "../../bridge-clients/starknet-bridge-client" }
+hypercore-bridge-client = { path = "../../bridge-clients/hypercore-bridge-client" }
 starknet.workspace = true
 near-mpc-contract-interface.workspace = true
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -251,6 +251,12 @@ pub enum InitTransferArgs {
     ///   `OmniBridge.initTransfer`; `fee` is paid out of `amount`, `message`
     ///   is forwarded with the bridge event.
     ///
+    /// For the **inbound** direction (any chain → HyperCore Core user) see
+    /// [`FinTransferArgs::EvmFinTransfer`]: target `chain_kind = HyperEvm`
+    /// with a non-empty `message` on the source-side `init_transfer` and
+    /// the contract-side message-length dispatch parks the supply at
+    /// `HlBridgeToken._systemAddress` so HyperCore credits the user.
+    ///
     /// `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
     /// the bridge ERC20 address. `amount` is in bridge ERC20 wei units;
     /// `decimals` is the bridge token's decimals, formatted as the wire

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -29,6 +29,9 @@ use omni_types::{
 };
 
 use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
+use hypercore_bridge_client::{
+    encode_init_transfer_action, encode_transfer_action, format_amount, HyperCoreBridgeClient,
+};
 use near_bridge_client::btc::{
     BtcConfirmationContext, BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
     BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg, FinBtcTransferArgs,
@@ -65,6 +68,7 @@ pub struct OmniConnector {
     pol_bridge_client: Option<EvmBridgeClient>,
     hyperevm_bridge_client: Option<EvmBridgeClient>,
     abs_bridge_client: Option<EvmBridgeClient>,
+    hypercore_bridge_client: Option<HyperCoreBridgeClient>,
     solana_bridge_client: Option<SolanaBridgeClient>,
     fogo_bridge_client: Option<SolanaBridgeClient>,
     wormhole_bridge_client: Option<WormholeBridgeClient>,
@@ -237,6 +241,43 @@ pub enum InitTransferArgs {
         native_fee: u128,
         message: String,
     },
+    /// HyperCore -> NEAR/other-chain via `sendToEvmWithData` with
+    /// `ACTION_INIT_TRANSFER`. Releases `amount` from the HlBridgeToken
+    /// system-address pool through `OmniBridge.initTransfer`.
+    ///
+    /// - `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
+    ///   the bridge ERC20 address.
+    /// - `amount` is in bridge ERC20 wei units. `decimals` is the bridge
+    ///   token's decimals. The connector formats `amount * 10^-decimals` as
+    ///   the Hyperliquid wire decimal string.
+    /// - The bridge token's decimals MUST equal Core's `szDecimals +
+    ///   evmExtraWeiDecimals` (the HyperCore<->HyperEVM linking invariant). If
+    ///   the token was linked incorrectly, the formatted amount will not
+    ///   match the user's Core spot balance precision.
+    HyperCoreInitTransfer {
+        token: String,
+        hl_bridge_token: Address,
+        amount: u128,
+        decimals: u8,
+        recipient: OmniAddress,
+        fee: u128,
+        message: String,
+        gas_limit: Option<u64>,
+    },
+    /// HyperCore -> HyperEVM via `sendToEvmWithData` with `ACTION_TRANSFER`.
+    /// Releases `amount` from the HlBridgeToken system-address pool to
+    /// `evm_recipient` on HyperEVM. No bridge involvement.
+    ///
+    /// Same `decimals` invariant as [`HyperCoreInitTransfer`]: must equal
+    /// Core's `szDecimals + evmExtraWeiDecimals`.
+    HyperCoreEvmTransfer {
+        token: String,
+        hl_bridge_token: Address,
+        amount: u128,
+        decimals: u8,
+        evm_recipient: Address,
+        gas_limit: Option<u64>,
+    },
 }
 
 pub enum FinTransferArgs {
@@ -272,6 +313,16 @@ pub enum FinTransferArgs {
         prefetched: Option<PrefetchedTxData>,
         transaction_options: TransactionOptions,
     },
+    /// Finalize a NEAR-originated transfer on an EVM chain.
+    ///
+    /// For inbound-to-HyperCore (deliver to a HyperCore Core user): set
+    /// `chain_kind = ChainKind::HyperEvm` and ensure the source-chain
+    /// `init_transfer` was called with a non-empty `message`. The OmniBridge
+    /// contract dispatches `finTransfer` to the 3-arg `mint(addr, amt, bytes)`
+    /// when `message.length > 0`, which `HlBridgeToken` redirects to its
+    /// `_systemAddress` pool so HyperCore picks up the balance. An empty
+    /// `message` lands the supply directly on the HyperEVM recipient via the
+    /// 2-arg `mint(addr, amt)`.
     EvmFinTransfer {
         chain_kind: ChainKind,
         event: OmniBridgeEvent,
@@ -2749,7 +2800,90 @@ impl OmniConnector {
                 .starknet_init_transfer(token, amount, fee, native_fee, recipient, message)
                 .await
                 .map(|tx_hash| format!("{tx_hash:#066x}")),
+            InitTransferArgs::HyperCoreInitTransfer {
+                token,
+                hl_bridge_token,
+                amount,
+                decimals,
+                recipient,
+                fee,
+                message,
+                gas_limit,
+            } => self
+                .hypercore_init_transfer(
+                    token,
+                    hl_bridge_token,
+                    amount,
+                    decimals,
+                    recipient,
+                    fee,
+                    message,
+                    gas_limit,
+                )
+                .await
+                .map(|tx_hash| format!("{tx_hash:?}")),
+            InitTransferArgs::HyperCoreEvmTransfer {
+                token,
+                hl_bridge_token,
+                amount,
+                decimals,
+                evm_recipient,
+                gas_limit,
+            } => self
+                .hypercore_evm_transfer(
+                    token,
+                    hl_bridge_token,
+                    amount,
+                    decimals,
+                    evm_recipient,
+                    gas_limit,
+                )
+                .await
+                .map(|tx_hash| format!("{tx_hash:?}")),
         }
+    }
+
+    /// HyperCore -> NEAR/other chain. Encodes `ACTION_INIT_TRANSFER`, signs and
+    /// posts the Hyperliquid action, blocks on the HyperEVM `CoreReceived` log.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn hypercore_init_transfer(
+        &self,
+        token: String,
+        hl_bridge_token: Address,
+        amount: u128,
+        decimals: u8,
+        recipient: OmniAddress,
+        fee: u128,
+        message: String,
+        gas_limit: Option<u64>,
+    ) -> Result<TxHash> {
+        let client = self.hypercore_bridge_client()?;
+        let amount_str = format_amount(amount, decimals);
+        let data = encode_init_transfer_action(fee, &recipient, &message);
+        let tx_hash = client
+            .send_to_evm_with_data(token, amount_str, hl_bridge_token, data, gas_limit)
+            .await?;
+        Ok(tx_hash)
+    }
+
+    /// HyperCore -> HyperEVM. Encodes `ACTION_TRANSFER`, signs and posts the
+    /// Hyperliquid action, blocks on the HyperEVM `CoreReceived` log.
+    pub async fn hypercore_evm_transfer(
+        &self,
+        token: String,
+        hl_bridge_token: Address,
+        amount: u128,
+        decimals: u8,
+        evm_recipient: Address,
+        gas_limit: Option<u64>,
+    ) -> Result<TxHash> {
+        let client = self.hypercore_bridge_client()?;
+        let amount_str = format_amount(amount, decimals);
+        let data = encode_transfer_action(evm_recipient);
+        let tx_hash = client
+            .send_to_evm_with_data(token, amount_str, hl_bridge_token, data, gas_limit)
+            .await?;
+        Ok(tx_hash)
     }
 
     pub async fn fin_transfer(&self, fin_transfer_args: FinTransferArgs) -> Result<String> {
@@ -3112,6 +3246,14 @@ impl OmniConnector {
             ));
         }
         Ok(())
+    }
+
+    pub fn hypercore_bridge_client(&self) -> Result<&HyperCoreBridgeClient> {
+        self.hypercore_bridge_client
+            .as_ref()
+            .ok_or(BridgeSdkError::ConfigError(
+                "HyperCore bridge client is not configured".to_string(),
+            ))
     }
 
     pub fn evm_bridge_client(&self, chain_kind: ChainKind) -> Result<&EvmBridgeClient> {

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -257,18 +257,19 @@ pub enum InitTransferArgs {
     /// the contract-side message-length dispatch parks the supply at
     /// `HlBridgeToken._systemAddress` so HyperCore credits the user.
     ///
-    /// `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
-    /// the bridge ERC20 address. `amount` is in bridge ERC20 wei units;
-    /// `decimals` is the bridge token's decimals, formatted as the wire
-    /// decimal string via `amount / 10^decimals`. The bridge token's
-    /// decimals MUST equal Core's `szDecimals + evmExtraWeiDecimals` (the
-    /// HyperCore<->HyperEVM linking invariant); if linked incorrectly the
-    /// formatted amount won't match the user's Core spot balance precision.
+    /// `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`).
+    /// `amount` is in bridge ERC20 wei units.
+    ///
+    /// `hl_bridge_token` and `decimals` may be `None`, in which case the
+    /// connector resolves them via `POST /info {"type":"spotMeta"}` —
+    /// `hl_bridge_token` from the token's `evmContract.address`, `decimals`
+    /// from `weiDecimals + evm_extra_wei_decimals`. Pass `Some` explicitly to
+    /// skip the round-trip when you already have the values.
     HyperCoreTransfer {
         token: String,
-        hl_bridge_token: Address,
+        hl_bridge_token: Option<Address>,
         amount: u128,
-        decimals: u8,
+        decimals: Option<u8>,
         recipient: OmniAddress,
         fee: u128,
         message: String,
@@ -2826,19 +2827,33 @@ impl OmniConnector {
     /// `ACTION_INIT_TRANSFER` (route through `OmniBridge.initTransfer`).
     /// Signs the Hyperliquid action, posts to `/exchange`, and blocks on the
     /// HyperEVM `CoreReceived` log.
+    ///
+    /// `hl_bridge_token` and `decimals` are resolved from Hyperliquid's
+    /// `spotMeta` when either is `None`. Provide both explicitly to skip the
+    /// `/info` round-trip when you already know them.
     #[allow(clippy::too_many_arguments)]
     pub async fn hypercore_transfer(
         &self,
         token: String,
-        hl_bridge_token: Address,
+        hl_bridge_token: Option<Address>,
         amount: u128,
-        decimals: u8,
+        decimals: Option<u8>,
         recipient: OmniAddress,
         fee: u128,
         message: String,
         gas_limit: Option<u64>,
     ) -> Result<TxHash> {
         let client = self.hypercore_bridge_client()?;
+        let (hl_bridge_token, decimals) = match (hl_bridge_token, decimals) {
+            (Some(addr), Some(d)) => (addr, d),
+            _ => {
+                let resolved = client.resolve_spot_token(&token).await?;
+                (
+                    hl_bridge_token.unwrap_or(resolved.hl_bridge_token),
+                    decimals.unwrap_or(resolved.decimals),
+                )
+            }
+        };
         let amount_str = format_amount(amount, decimals);
         let data = match &recipient {
             OmniAddress::HyperEvm(addr) => encode_transfer_action(Address::from_slice(&addr.0)),

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -248,8 +248,8 @@ pub enum InitTransferArgs {
     /// - `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
     ///   the bridge ERC20 address.
     /// - `amount` is in bridge ERC20 wei units. `decimals` is the bridge
-    ///   token's decimals. The connector formats `amount * 10^-decimals` as
-    ///   the Hyperliquid wire decimal string.
+    ///   token's decimals. The connector formats `amount / 10^decimals` as a
+    ///   minimal decimal string for the Hyperliquid wire field.
     /// - The bridge token's decimals MUST equal Core's `szDecimals +
     ///   evmExtraWeiDecimals` (the HyperCore<->HyperEVM linking invariant). If
     ///   the token was linked incorrectly, the formatted amount will not
@@ -2821,7 +2821,7 @@ impl OmniConnector {
                     gas_limit,
                 )
                 .await
-                .map(|tx_hash| format!("{tx_hash:?}")),
+                .map(|tx_hash| tx_hash.to_string()),
             InitTransferArgs::HyperCoreEvmTransfer {
                 token,
                 hl_bridge_token,
@@ -2839,7 +2839,7 @@ impl OmniConnector {
                     gas_limit,
                 )
                 .await
-                .map(|tx_hash| format!("{tx_hash:?}")),
+                .map(|tx_hash| tx_hash.to_string()),
         }
     }
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -241,20 +241,24 @@ pub enum InitTransferArgs {
         native_fee: u128,
         message: String,
     },
-    /// HyperCore -> NEAR/other-chain via `sendToEvmWithData` with
-    /// `ACTION_INIT_TRANSFER`. Releases `amount` from the HlBridgeToken
-    /// system-address pool through `OmniBridge.initTransfer`.
+    /// HyperCore -> any destination via `sendToEvmWithData`. The connector
+    /// picks the on-chain action based on `recipient`:
     ///
-    /// - `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
-    ///   the bridge ERC20 address.
-    /// - `amount` is in bridge ERC20 wei units. `decimals` is the bridge
-    ///   token's decimals. The connector formats `amount / 10^decimals` as a
-    ///   minimal decimal string for the Hyperliquid wire field.
-    /// - The bridge token's decimals MUST equal Core's `szDecimals +
-    ///   evmExtraWeiDecimals` (the HyperCore<->HyperEVM linking invariant). If
-    ///   the token was linked incorrectly, the formatted amount will not
-    ///   match the user's Core spot balance precision.
-    HyperCoreInitTransfer {
+    /// - `OmniAddress::HyperEvm(addr)` → `ACTION_TRANSFER`. Pool release
+    ///   directly from `HlBridgeToken._systemAddress` to `addr` on HyperEVM;
+    ///   `fee` and `message` are unused.
+    /// - any other variant → `ACTION_INIT_TRANSFER`. Routes through
+    ///   `OmniBridge.initTransfer`; `fee` is paid out of `amount`, `message`
+    ///   is forwarded with the bridge event.
+    ///
+    /// `token` is the Hyperliquid spot identifier (`"NAME:0x<32hex>"`), NOT
+    /// the bridge ERC20 address. `amount` is in bridge ERC20 wei units;
+    /// `decimals` is the bridge token's decimals, formatted as the wire
+    /// decimal string via `amount / 10^decimals`. The bridge token's
+    /// decimals MUST equal Core's `szDecimals + evmExtraWeiDecimals` (the
+    /// HyperCore<->HyperEVM linking invariant); if linked incorrectly the
+    /// formatted amount won't match the user's Core spot balance precision.
+    HyperCoreTransfer {
         token: String,
         hl_bridge_token: Address,
         amount: u128,
@@ -262,20 +266,6 @@ pub enum InitTransferArgs {
         recipient: OmniAddress,
         fee: u128,
         message: String,
-        gas_limit: Option<u64>,
-    },
-    /// HyperCore -> HyperEVM via `sendToEvmWithData` with `ACTION_TRANSFER`.
-    /// Releases `amount` from the HlBridgeToken system-address pool to
-    /// `evm_recipient` on HyperEVM. No bridge involvement.
-    ///
-    /// Same `decimals` invariant as [`HyperCoreInitTransfer`]: must equal
-    /// Core's `szDecimals + evmExtraWeiDecimals`.
-    HyperCoreEvmTransfer {
-        token: String,
-        hl_bridge_token: Address,
-        amount: u128,
-        decimals: u8,
-        evm_recipient: Address,
         gas_limit: Option<u64>,
     },
 }
@@ -2800,7 +2790,7 @@ impl OmniConnector {
                 .starknet_init_transfer(token, amount, fee, native_fee, recipient, message)
                 .await
                 .map(|tx_hash| format!("{tx_hash:#066x}")),
-            InitTransferArgs::HyperCoreInitTransfer {
+            InitTransferArgs::HyperCoreTransfer {
                 token,
                 hl_bridge_token,
                 amount,
@@ -2810,7 +2800,7 @@ impl OmniConnector {
                 message,
                 gas_limit,
             } => self
-                .hypercore_init_transfer(
+                .hypercore_transfer(
                     token,
                     hl_bridge_token,
                     amount,
@@ -2822,31 +2812,16 @@ impl OmniConnector {
                 )
                 .await
                 .map(|tx_hash| tx_hash.to_string()),
-            InitTransferArgs::HyperCoreEvmTransfer {
-                token,
-                hl_bridge_token,
-                amount,
-                decimals,
-                evm_recipient,
-                gas_limit,
-            } => self
-                .hypercore_evm_transfer(
-                    token,
-                    hl_bridge_token,
-                    amount,
-                    decimals,
-                    evm_recipient,
-                    gas_limit,
-                )
-                .await
-                .map(|tx_hash| tx_hash.to_string()),
         }
     }
 
-    /// HyperCore -> NEAR/other chain. Encodes `ACTION_INIT_TRANSFER`, signs and
-    /// posts the Hyperliquid action, blocks on the HyperEVM `CoreReceived` log.
+    /// HyperCore -> any destination. Picks `ACTION_TRANSFER` when the
+    /// recipient is a HyperEVM address (direct pool release), otherwise
+    /// `ACTION_INIT_TRANSFER` (route through `OmniBridge.initTransfer`).
+    /// Signs the Hyperliquid action, posts to `/exchange`, and blocks on the
+    /// HyperEVM `CoreReceived` log.
     #[allow(clippy::too_many_arguments)]
-    pub async fn hypercore_init_transfer(
+    pub async fn hypercore_transfer(
         &self,
         token: String,
         hl_bridge_token: Address,
@@ -2859,27 +2834,10 @@ impl OmniConnector {
     ) -> Result<TxHash> {
         let client = self.hypercore_bridge_client()?;
         let amount_str = format_amount(amount, decimals);
-        let data = encode_init_transfer_action(fee, &recipient, &message);
-        let tx_hash = client
-            .send_to_evm_with_data(token, amount_str, hl_bridge_token, data, gas_limit)
-            .await?;
-        Ok(tx_hash)
-    }
-
-    /// HyperCore -> HyperEVM. Encodes `ACTION_TRANSFER`, signs and posts the
-    /// Hyperliquid action, blocks on the HyperEVM `CoreReceived` log.
-    pub async fn hypercore_evm_transfer(
-        &self,
-        token: String,
-        hl_bridge_token: Address,
-        amount: u128,
-        decimals: u8,
-        evm_recipient: Address,
-        gas_limit: Option<u64>,
-    ) -> Result<TxHash> {
-        let client = self.hypercore_bridge_client()?;
-        let amount_str = format_amount(amount, decimals);
-        let data = encode_transfer_action(evm_recipient);
+        let data = match &recipient {
+            OmniAddress::HyperEvm(addr) => encode_transfer_action(Address::from_slice(&addr.0)),
+            _ => encode_init_transfer_action(fee, &recipient, &message),
+        };
         let tx_hash = client
             .send_to_evm_with_data(token, amount_str, hl_bridge_token, data, gas_limit)
             .await?;


### PR DESCRIPTION
## Summary

Adds a new `hypercore-bridge-client` crate plus connector/CLI wiring so a HyperCore user can call **one** Hyperliquid Core action (`sendToEvmWithData`) and have their tokens delivered to NEAR / Solana / any supported chain — no manual HyperEVM tx in between.

Two flows are exposed:
- **`ACTION_INIT_TRANSFER` (`0x01`)** — Core → NEAR/other-chain via `OmniBridge.initTransfer`. The HlBridgeToken contract releases the bridged amount from its system-address pool and routes it through the bridge.
- **`ACTION_TRANSFER` (`0x00`)** — Core → arbitrary HyperEVM recipient (pool release without bridge involvement).

Also corrects the HyperEVM bridge factory default address (`0x0000…` placeholder → `0xf353b40fC144d1c6c5BCdda712fa6De833016aF9`), matching the deployed proxy on both mainnet and testnet.

## Why

`HlBridgeToken` (omni-bridge PR #624) already accepts a `coreReceiveWithData(...)` callback from Hyperliquid's system address. What was missing was the SDK side: signing Hyperliquid user-signed actions (EIP-712), posting them to `/exchange`, and reliably correlating the resulting on-chain effect. This PR fills that gap.

## What's in the diff

**New crate: `bridge-sdk/bridge-clients/hypercore-bridge-client/`** (~890 LoC)

- `action.rs` — `SendToEvmWithDataAction` JSON wire struct, `HyperliquidNetwork` enum (mainnet/testnet URLs + chain ids 999/998), `format_amount(u128, decimals) → String` for the decimal-string wire format.
- `encoders.rs` — `encode_init_transfer_action(fee, &OmniAddress, &str)` and `encode_transfer_action(Address)`. Tag constants exposed.
- `signing.rs` — EIP-712 `sign_action()` with manual domain/struct hash + `keccak256(0x19 || 0x01 || dom || struct)`. Round-trip signer-recovery test included.
- `client.rs` (= `hypercore_bridge_client.rs`) — `HyperCoreBridgeClient`: posts the signed action to `/exchange`, then polls HyperEVM for the resulting `CoreReceived` log (filtered by `address + topic0 + topic1=signer + data == expected`). Returns the HyperEVM `TxHash` (or the full `CoreReceivedLog` via the `_detailed` variant).
- `builder.rs` — builder pattern matching the rest of the workspace, with `http_timeout` (default 30s), `poll_interval` (1.5s), `poll_timeout` (60s) all configurable.
- `error.rs` — `thiserror`-based errors flow through to `BridgeSdkError` via `From` impl in `bridge-connector-common`.

**Edits to existing crates**

- `evm-bridge-client`: new `sol! HlBridgeToken { event CoreReceived(...) }`, `CoreReceivedFilter`, `CoreInitiatedTransfer`, plus `get_core_received_log()` and `parse_core_initiated_transfer()` helpers. The correlator is needed because `OmniBridge.InitTransfer.sender` is the HlBridgeToken contract address (not the Core user) when the transfer was triggered via the callback — without the `CoreReceived` correlation, indexers can't attribute back to the originating Core account.
- `bridge-connector-common`: `From<HyperCoreBridgeClientError>` for `BridgeSdkError`, plus three new variants (`HyperCoreError`, `HyperCoreActionRejected`, `HyperCorePollTimeout`).
- `omni-connector`: new field `hypercore_bridge_client`, two new `InitTransferArgs` variants (`HyperCoreInitTransfer`, `HyperCoreEvmTransfer`), dispatch arms in `init_transfer`, `hypercore_bridge_client()` accessor. Doc-comment on `FinTransferArgs::EvmFinTransfer` explaining the contract-side message-length dispatch that delivers inbound supply to a HyperCore user.
- `bridge-cli`: `hypercore_api` + `hypercore_signature_chain_id` config fields wired through `or()` / `env_config()` / `default_config()` for mainnet/testnet/devnet; two subcommands `hyper-core-init-transfer` and `hyper-core-evm-transfer`. HyperEVM bridge factory address corrected from placeholder to deployed proxy.

## Verification

```
cargo build --workspace        →  PASS
cargo clippy --workspace       →  3 warnings, all pre-existing on main (verified via stash)
cargo test --workspace         →  PASS
cargo fmt --check              →  clean
cargo test -p hypercore-bridge-client  →  8/8 pass
```

The 8 unit tests cover:
- `format_amount` edge cases (zero, leading zeros, trailing-zero trim)
- ABI-encode/decode round trip for both `ACTION_TRANSFER` and `ACTION_INIT_TRANSFER` data layouts
- `signatureChainId` parsing
- EIP-712 domain separator determinism
- Struct hash changes with each field (sensitivity check)
- `sign_action_recovers_signer` — sign with a known key, recover from the digest, assert the recovered address matches

## Known risks / outstanding

✅ **EIP-712 type string validated against Hyperliquid testnet.** `cargo test -p hypercore-bridge-client testnet_l1 -- --ignored --nocapture` with two fresh random keys returned `{"status":"err","response":"Must deposit before performing actions. User: 0x<our-signing-address>"}` — Hyperliquid's L1 recovered exactly the address we signed with from our digest. Confirmed correct: field order, integer widths (`uint32 destinationChainId`, `uint64 gasLimit`, `uint64 nonce`), `signatureChainId` placement (domain only), inclusion of `sourceDex`/`addressEncoding` in the signed payload, and `data` serialized as `0x`-prefixed lowercase hex. Test stays as `#[ignore]` so CI doesn't hit network; doc comments in `signing.rs` reflect verified status. Don't use the Anvil `0xac09…` well-known key for the smoke test — that address is configured as a multi-sig account on testnet by someone else, which masks the address-recovery signal with a less informative `"Multi-sig required"` error.

⚠️ **No full money-transfer E2E in this PR.** The signing pipeline is verified, but an actual successful bridge transfer (funded HyperCore testnet account → linked spot token → deployed `HlBridgeToken` → bridge through to a NEAR account) hasn't been executed. Worth doing before any mainnet usage to confirm gas defaults, polling timeouts, and the `parse_core_initiated_transfer` correlator behave on real traffic. Less critical than the EIP-712 risk was — protocol-level shape is no longer the suspect.

ℹ️ `ChainKind::HyperCore` was **deferred** (Decision A). Inbound-to-Core works today via the contract-side message-length dispatch on `EvmFinTransfer { chain_kind: HyperEvm, … }` with a non-empty `message`; documented on the variant. Adding a dedicated `ChainKind::HyperCore` is a follow-up if the UX warrants it (requires an `omni-types` bump).

ℹ️ `ClaimFeeArgs` has no `WithVaaProofTx` variant — this affects all Wormhole-using chains (Arb, Base, Bnb, Pol, HyperEvm) equally, not specifically HyperEvm. Pre-existing gap.


## Test plan

- [ ] `cargo build --workspace` (already passes locally)
- [ ] `cargo test --workspace` (already passes locally)
- [ ] **E2E testnet smoke test** (gate before merge):
  - Deploy or use an existing `HlBridgeToken` on HyperEVM testnet
  - Fund a Core account with the linked spot token
  - `bridge-cli testnet hyper-core-init-transfer --token <NAME:tokenId> --hl-token <addr> --amount <wei> --decimals <u8> --recipient near:alice.testnet --fee 0 --message ref=hypercore`
  - Confirm `/exchange` returns `{"status":"ok"}`
  - Confirm `CoreReceived(sender=<core_user>, action=1, …)` lands on HyperEVM
  - Confirm `OmniBridge.InitTransfer` is emitted in the same tx with `sender == HlBridgeToken address`
  - Assert `EvmBridgeClient::parse_core_initiated_transfer(tx_hash, hl_bridge_token)` returns both events correlated
- [ ] If `/exchange` rejects with a signature error, iterate on the EIP-712 type list per the risk note above
