### PR TITLE
feat(utxo): pick selection algorithm by pool size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.59"
+version = "0.3.60"
 dependencies = [
  "alloy",
  "clap",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -11116,7 +11116,7 @@ dependencies = [
 
 [[package]]
 name = "utxo-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitcoin",
  "k256",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.59"
+version = "0.3.60"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -1114,6 +1114,7 @@ impl NearBridgeClient {
             max_change_number: config.max_change_number.into(),
             passive_management_lower_limit: config.passive_management_lower_limit,
             passive_management_upper_limit: config.passive_management_upper_limit,
+            active_management_upper_limit: config.active_management_upper_limit,
         })
     }
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -3796,19 +3796,26 @@ impl OmniConnector {
             .get_withdraw_selection_params(chain)
             .await?;
 
+        // Algorithm selection:
+        // - No budget (`max_gas_fee = None`) ⇒ always the random selector.
+        // - With a budget, only consolidate (anchor-fill) when the pool is
+        //   above the active-management upper limit (`pool_size >
+        //   active_management_upper_limit`); otherwise fall back to random.
         let selection = match max_gas_fee {
-            Some(budget) => utxo_utils::choose_utxos_anchor_fill(
-                amount,
-                utxos,
-                pool_size,
-                &params,
-                chain,
-                fee_rate,
-                budget,
-                enable_orchard,
-                change_reserve.unwrap_or(0),
-            ),
-            None => utxo_utils::choose_utxos_random_no_payment(
+            Some(budget) if pool_size > params.active_management_upper_limit => {
+                utxo_utils::choose_utxos_anchor_fill(
+                    amount,
+                    utxos,
+                    pool_size,
+                    &params,
+                    chain,
+                    fee_rate,
+                    budget,
+                    enable_orchard,
+                    change_reserve.unwrap_or(0),
+                )
+            }
+            _ => utxo_utils::choose_utxos_random_no_payment(
                 amount,
                 utxos,
                 pool_size,

--- a/bridge-sdk/utxo-utils/Cargo.toml
+++ b/bridge-sdk/utxo-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-utils"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/utxo-utils/src/anchor_fill.rs
+++ b/bridge-sdk/utxo-utils/src/anchor_fill.rs
@@ -437,7 +437,7 @@ mod tests {
             max_change_number: 10,
             passive_management_lower_limit: 0,
             passive_management_upper_limit: 6000,
-            active_management_upper_limit: 8000,
+            active_management_upper_limit: 4000,
         }
     }
 
@@ -687,7 +687,7 @@ mod tests {
             max_change_number: 5,
             passive_management_lower_limit: 10,
             passive_management_upper_limit: 200,
-            active_management_upper_limit: 300,
+            active_management_upper_limit: 150,
         };
 
         let mut pool = HashMap::new();
@@ -812,7 +812,7 @@ mod tests {
             max_change_number: 5,
             passive_management_lower_limit: 10,
             passive_management_upper_limit: 200,
-            active_management_upper_limit: 300,
+            active_management_upper_limit: 150,
         };
         let pool = pool_100_tiered();
         let pool_size = pool.len() as u32;

--- a/bridge-sdk/utxo-utils/src/anchor_fill.rs
+++ b/bridge-sdk/utxo-utils/src/anchor_fill.rs
@@ -437,6 +437,7 @@ mod tests {
             max_change_number: 10,
             passive_management_lower_limit: 0,
             passive_management_upper_limit: 6000,
+            active_management_upper_limit: 8000,
         }
     }
 
@@ -686,6 +687,7 @@ mod tests {
             max_change_number: 5,
             passive_management_lower_limit: 10,
             passive_management_upper_limit: 200,
+            active_management_upper_limit: 300,
         };
 
         let mut pool = HashMap::new();
@@ -810,6 +812,7 @@ mod tests {
             max_change_number: 5,
             passive_management_lower_limit: 10,
             passive_management_upper_limit: 200,
+            active_management_upper_limit: 300,
         };
         let pool = pool_100_tiered();
         let pool_size = pool.len() as u32;

--- a/bridge-sdk/utxo-utils/src/lib.rs
+++ b/bridge-sdk/utxo-utils/src/lib.rs
@@ -201,6 +201,7 @@ pub struct WithdrawSelectionParams {
     pub max_change_number: usize,
     pub passive_management_lower_limit: u32,
     pub passive_management_upper_limit: u32,
+    pub active_management_upper_limit: u32,
 }
 
 /// Splits `change` into `n` outputs each strictly less than `max_per_piece`


### PR DESCRIPTION
With a gas budget (`max_gas_fee = Some`), anchor-fill now runs only when the
pool is actually bloated (`pool_size > active_management_upper_limit`),
otherwise the regular random selector is used. Without a budget — random, as
before.

This prevents the UTXO count from shrinking too much: anchor-fill aggressively
consolidates inputs, so we only want it once the pool is large enough that
active management would kick in anyway.

The `active_management_upper_limit` threshold comes from the contract config
(`get_config`) and was added to `WithdrawSelectionParams`.