### PR TITLE
feat: support for aptos

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,0 +1,99 @@
+You are reviewing a Rust pull request for **bridge-sdk-rs** — the Omni Bridge SDK: a Rust workspace (library + `bridge-cli`) that builds, signs, and submits cross-chain token-bridging transactions and proofs for the [Omni Bridge](https://github.com/Near-One/omni-bridge) protocol across NEAR, EVM chains (Ethereum, Arbitrum, Base, BNB, Polygon, HyperEVM, Abstract), Solana, Fogo, Bitcoin, Zcash, Starknet, and Aptos. Correctness here means: **every transaction/proof the SDK constructs is byte-exact for the target chain's on-chain contract, and adding or changing a chain is wired through every layer so nothing is silently mis-routed.**
+
+**IMPORTANT - CONTEXT AWARENESS:**
+- Review any existing PR comments and discussions provided alongside this prompt before giving feedback
+- Do not duplicate points already raised in existing discussions
+- If a resolved thread addressed an issue, do not re-raise it
+- You have read access to the checked-out repository — use `Read`, `Grep`, and `Glob` to verify how changes interact with surrounding code, look up referenced types/functions/tests, and consult [CLAUDE.md] for project structure, key concepts (per-chain bridge clients, `OmniConnector`, builder pattern, exhaustive matching), and conventions
+- Use `gh pr diff` for the full diff and `gh pr view` for PR metadata
+
+PRIORITY CHECKS (report only if found):
+
+1. Cross-chain correctness & exhaustive matching (the cardinal sins of this codebase)
+   - Exhaustive matches on `ChainKind` / `OmniAddress` (from `omni-types`) must route a chain to the RIGHT client/helper — not merely compile. A new chain folded into a wildcard (`_ =>`) or an "unsupported" arm where it should be handled, or into the WRONG arm (e.g. an EVM arm for a non-EVM chain), is a silent bug
+   - Address conversions must use the correct inner type per chain: EVM = `H160`, Starknet/Aptos = `H256` (32-byte), Solana/Fogo = `Pubkey`, Btc/Zcash = `String`. A mismatched conversion corrupts the recipient/token
+   - `is_evm_chain()` / `is_utxo_chain()` / `is_svm_chain()` gating must match the chain's real nature
+
+2. On-chain ABI / calldata fidelity
+   - The bytes the SDK builds must match the target contract's entry function / calldata field-for-field: EVM (`alloy` `sol!` types, `finTransfer` overloads), Solana (instruction data), Starknet (`Felt` calldata, Cairo `ByteArray`, u256 low/high word order), Aptos (BCS-encoded entry args + `RawTransaction` signing message), NEAR (borsh args). Verify argument ORDER, integer widths (u64/u128), decimals normalization, and nonce handling
+   - Amounts: `u128`→`u64` truncation, decimal scaling between source/target chains, `checked_*` vs silent wrap/`as`
+
+3. Proof construction & determinism
+   - MPC `ForeignTxSignPayload` must be byte-identical to what the MPC node reconstructs off-chain (event/log canonicalization, address padding, tx-id byte order, finality) — any divergence makes the NEAR-side signature verification fail. Cross-check against the foreign-chain inspector in `github.com/near/mpc` when relevant
+   - Correct `ProofKind` per flow (fin_transfer ⇒ `InitTransfer`, bind_token ⇒ `DeployToken`, claim_fee ⇒ `FinTransfer`); wormhole VAA retrieval; EVM Merkle proofs against the light client
+
+4. Signatures & key handling
+   - 65-byte secp256k1 signatures split correctly (`r||s||v`, v=27/28 vs 0/1); the cross-chain MPC signature is distinct from a chain's own tx-signing key (e.g. Aptos Ed25519). Private keys/seeds must never be logged or embedded in errors
+
+5. Full wiring when adding/altering a chain
+   - A new chain must thread through ALL of: the per-chain bridge-client crate; `omni-connector` (client field on `OmniConnector`, the `OmniConnectorBuilder`, helper methods, the arg-enums `DeployTokenArgs`/`InitTransferArgs`/`FinTransferArgs`/`BindTokenArgs`/`ClaimFeeArgs`, and EVERY exhaustive `match`); `bridge-cli` (`CliConfig` struct + `or()` + `env_config()` + all THREE `default_config` network arms, `defaults.rs` constants, the subcommand + its match arm + the `omni_connector()` builder); `bridge-connector-common` (`From<XBridgeClientError> for BridgeSdkError` + error variants). A field added in the struct but dropped from `or()`/`env_config`/a `default_config` arm silently breaks the CLI precedence (CLI args > env vars > config file > defaults)
+
+6. Logic, error handling & robustness (general Rust)
+   - No `unwrap`/`expect`/panic in library code on attacker-controlled (recipient strings, token metadata, on-chain event data) or network input — these must propagate `Result`. `unwrap` is acceptable in `bridge-cli` command handlers and tests, and on a documented invariant (e.g. infallible BCS of a primitive)
+   - Missing retry/backoff or timeouts on RPC calls; blocking calls in async; unbounded loops
+   - Boundary cases: empty vecs, `None`/`Some`, u64/u128 overflow, off-by-one in nonces/indices
+
+7. Security
+   - Hardcoded secrets/credentials, private keys, or RPC URLs with embedded tokens leaking into logs, error messages, or committed config
+   - Injection / wedging via untrusted on-chain data (recipient strings and token metadata are attacker-controlled)
+   - External dependency revs (`omni-types`, `near-mpc-contract-interface`) must be pinned to immutable commits; flag a floating rev or a dependency-source change that could break reproducibility
+
+8. Code quality & conventions
+   - CI (`.github/workflows/security-analysis.yml`) gates on `cargo test --workspace` and runs (advisory) `cargo clippy --all-targets --workspace --no-deps --lib -- -D clippy::all -D clippy::pedantic` (with a small `-A` allow-list) plus `-D clippy::as_conversions -D clippy::unsafe_casting`. Flag obvious pedantic/`as`-conversion violations in NEW code (prefer `u64::from` / `TryFrom` over `as`)
+   - Follow the established patterns: `derive_builder` for `OmniConnector`; hand-rolled builders for the per-chain clients; one bridge-client crate per chain family; exhaustive matching (per CLAUDE.md). Flag gratuitous divergence
+
+REVIEW STYLE:
+- List only issues that should block the merge
+- Use bullet points, be direct and specific
+- Provide code suggestions for fixes when helpful
+- Do NOT comment on style, formatting, naming, or documentation unless it causes a bug
+- Do NOT restate what the diff already shows
+- If no critical issues found: approve with a one-line summary
+- Sign off with: ✅ (approved) or ⚠️ (issues found)
+
+REQUIRED OUTPUT STRUCTURE:
+
+The review body must follow this layout:
+
+```
+## Pull request overview
+
+<2–4 sentence narrative summary of what this PR does and why.>
+
+**Changes:**
+- <bullet list of substantive changes — group related edits>
+
+### Reviewed changes
+
+<details>
+<summary>Per-file summary</summary>
+
+| File | Description |
+| ---- | ----------- |
+| path/to/file.rs | What changed in this file |
+| ... | ... |
+
+</details>
+
+### Findings
+
+**Blocking** (must fix before merge):
+- `path/to/file.rs:LINE` — <description and concrete suggested fix>
+
+**Non-blocking** (nits, follow-ups, suggestions):
+- `path/to/file.rs:LINE` — <description>
+
+<Omit a category if empty.>
+
+<End with one of:>
+✅ Approved
+⚠️ Issues found
+```
+
+Anchor every finding with a `file:line` reference so reviewers can jump to the location.
+
+Consult the repository's [CLAUDE.md] for project-specific conventions (AGENTS.md points to the same file).
+Don't try to use `gh pr review` you don't have permissions for that and it will fail.
+Please always use `gh pr comment` to post your review instead.
+
+[CLAUDE.md]: ../../CLAUDE.md

--- a/.github/scripts/fetch-pr-comments.sh
+++ b/.github/scripts/fetch-pr-comments.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetches PR comments via GraphQL and formats them for Claude review.
+#
+# Required env vars: GH_TOKEN, PR_NUMBER, REPO_OWNER, REPO_NAME
+# Outputs: /tmp/pr_comments_context.txt
+
+QUERY='query($owner: String!, $repo: String!, $prNumber: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      comments(first: 100) {
+        totalCount
+        nodes {
+          author { login }
+          body
+          createdAt
+        }
+      }
+      reviewThreads(first: 100) {
+        totalCount
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            nodes {
+              author { login }
+              body
+              createdAt
+              diffHunk
+            }
+          }
+        }
+      }
+      reviews(first: 50) {
+        totalCount
+        nodes {
+          author { login }
+          body
+          state
+          createdAt
+        }
+      }
+    }
+  }
+}'
+
+# Execute GraphQL query and check for errors
+if ! COMMENTS_JSON=$(gh api graphql \
+  -f query="$QUERY" \
+  -f owner="$REPO_OWNER" \
+  -f repo="$REPO_NAME" \
+  -F prNumber="$PR_NUMBER"); then
+  echo "Warning: Failed to fetch PR comments. Proceeding without comment context."
+  echo "⚠️ Unable to fetch existing comments due to API error." > /tmp/pr_comments_context.txt
+  exit 0
+fi
+
+# Project the relevant fields to JSON context for Claude, truncating long diff
+# hunks to keep the token budget bounded. The LLM reads JSON directly, so no
+# prose formatting is needed.
+# Write to file instead of env var to avoid E2BIG on large PRs
+if [ -n "$COMMENTS_JSON" ]; then
+  echo "$COMMENTS_JSON" > /tmp/pr_comments_json.txt
+  if ! jq '
+      # Truncate a diff hunk to ~$max chars at line boundaries (never mid-line).
+      def truncate_hunk($max):
+        if (length <= $max) then .
+        else
+          (reduce (split("\n")[]) as $line ({acc: [], count: 0, done: false};
+             if .done then .
+             elif ((.count + ($line | length) + 1) > $max and (.acc | length) > 0)
+             then .done = true
+             else {acc: (.acc + [$line]), count: (.count + ($line | length) + 1), done: false}
+             end)
+           | .acc | join("\n")) + "\n... (truncated)"
+        end;
+      (.data.repository.pullRequest // {}) | {
+        comments: [(.comments.nodes // [])[] | {author: .author.login, body, createdAt}],
+        reviews: [(.reviews.nodes // [])[] | select((.body // "") != "") | {author: .author.login, state, body, createdAt}],
+        threads: [(.reviewThreads.nodes // [])[] | {path, line, isResolved, isOutdated,
+          comments: [(.comments.nodes // [])[] | {author: .author.login, body, createdAt, diffHunk: ((.diffHunk // "") | truncate_hunk(500))}]}]
+      }' /tmp/pr_comments_json.txt > /tmp/pr_comments_context.txt; then
+    echo "⚠️ Unable to parse comment data." > /tmp/pr_comments_context.txt
+  fi
+else
+  echo "⚠️ No comments data to process." > /tmp/pr_comments_context.txt
+  exit 0
+fi

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,73 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]  # When PR is ready for review (not draft)
+  issue_comment:
+    types: [created]  # Listen for @claude mentions in PR comments
+
+jobs:
+  claude-review:
+    # Run if: (PR opened/ready AND not draft) OR @claude review in PR comment
+    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (contains(github.event.comment.body, '@claude review') ||
+        contains(github.event.comment.body, '@claude code review')))
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch PR Comments Context
+        id: fetch-comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: .github/scripts/fetch-pr-comments.sh
+
+      - name: Build review prompt
+        id: build-prompt
+        run: |
+          DELIM="PROMPT_EOF_$(uuidgen)"
+          {
+            echo "REVIEW_PROMPT<<$DELIM"
+            echo '<pr_context>'
+            echo "REPO: ${{ github.repository }}"
+            echo "PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}"
+            echo 'LANGUAGE: Rust'
+            echo '</pr_context>'
+            echo ''
+            echo '<existing_discussions>'
+            cat /tmp/pr_comments_context.txt
+            echo '</existing_discussions>'
+            echo ''
+            echo '<review_instructions>'
+            cat .github/prompts/pr-review.prompt.md
+            echo '</review_instructions>'
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2 # main @ Claude Code 2.1.128 / Agent SDK 0.2.128 (needed for --effort xhigh)
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API }}
+          prompt: ${{ env.REVIEW_PROMPT }}
+          claude_args: >-
+            --model claude-opus-4-8
+            --effort xhigh
+            --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "aptos-bridge-client"
+version = "0.1.0"
+dependencies = [
+ "bcs",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "near-mpc-contract-interface 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
+ "omni-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bcs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,12 +1811,13 @@ name = "bridge-cli"
 version = "0.3.60"
 dependencies = [
  "alloy",
+ "aptos-bridge-client",
  "clap",
  "dotenv",
  "evm-bridge-client",
  "light-client",
  "near-bridge-client",
- "near-mpc-contract-interface",
+ "near-mpc-contract-interface 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
  "near-primitives",
  "near-sdk",
  "omni-connector",
@@ -1813,6 +1842,7 @@ name = "bridge-connector-common"
 version = "0.3.3"
 dependencies = [
  "alloy",
+ "aptos-bridge-client",
  "eth-proof",
  "evm-bridge-client",
  "near-rpc-client",
@@ -2958,8 +2988,10 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.10.9",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3281,7 +3313,7 @@ dependencies = [
  "hex",
  "near-crypto",
  "near-jsonrpc-client",
- "near-mpc-contract-interface",
+ "near-mpc-contract-interface 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
  "near-primitives",
  "near-rpc-client",
  "near-token",
@@ -4904,6 +4936,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-primitives"
+version = "3.11.0"
+source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+dependencies = [
+ "borsh 1.6.1",
+ "derive_more",
+ "hex",
+ "near-account-id 2.6.0",
+ "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "mpl-token-metadata"
 version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,18 +4977,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "near-abi"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe0c8cdaf8369d8c78f2577d95673007c7f256c85752a66672be5244e2681a6"
-dependencies = [
- "borsh 1.6.1",
- "schemars 0.8.22",
- "semver 1.0.27",
- "serde",
 ]
 
 [[package]]
@@ -5080,7 +5114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "919d705b6dab5a7c6cc4b9a60e3025ed2f7cf3d4c3c32ad1a47264a4190e6409"
 dependencies = [
  "borsh 1.6.1",
- "schemars 0.8.22",
  "serde",
 ]
 
@@ -5136,6 +5169,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-mpc-bounded-collections"
+version = "0.0.1"
+source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+dependencies = [
+ "borsh 1.6.1",
+ "derive_more",
+ "hex",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "near-mpc-contract-interface"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5143,9 +5188,25 @@ checksum = "f7d826b114d1bae737a6c8e591756ab0c6542e64ef5a7b3bd54d72f51ff27139"
 dependencies = [
  "borsh 1.6.1",
  "derive_more",
- "near-mpc-bounded-collections",
- "near-mpc-crypto-types",
+ "near-mpc-bounded-collections 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-mpc-crypto-types 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars 0.8.22",
+ "serde",
+ "serde_repr",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "near-mpc-contract-interface"
+version = "0.0.1"
+source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+dependencies = [
+ "borsh 1.6.1",
+ "derive_more",
+ "mpc-primitives",
+ "near-mpc-bounded-collections 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
+ "near-mpc-crypto-types 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
  "serde",
  "serde_repr",
  "serde_with",
@@ -5169,6 +5230,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-mpc-crypto-types"
+version = "0.0.1"
+source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+dependencies = [
+ "borsh 1.6.1",
+ "bs58 0.5.1",
+ "derive_more",
+ "mpc-primitives",
+ "near-account-id 2.6.0",
+ "near-mpc-bounded-collections 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
+ "serde",
+ "serde_with",
+ "sha3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "near-mpc-sdk"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5176,8 +5254,8 @@ checksum = "d9a367e31f8849f58e671ea956ddc6e37bd2d60fa97a9e9b650454379a198a66"
 dependencies = [
  "borsh 1.6.1",
  "derive_more",
- "near-mpc-bounded-collections",
- "near-mpc-contract-interface",
+ "near-mpc-bounded-collections 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-mpc-contract-interface 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-mpc-signature-verifier",
 ]
 
@@ -5187,7 +5265,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd40041faf66e4548469d66629e61854d86e0706039ef6527a9ed4a88ebaef6"
 dependencies = [
- "near-mpc-contract-interface",
+ "near-mpc-contract-interface 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-sdk",
 ]
 
@@ -5325,7 +5403,6 @@ dependencies = [
  "base64 0.22.1",
  "borsh 1.6.1",
  "bs58 0.5.1",
- "near-abi",
  "near-account-id 2.6.0",
  "near-crypto",
  "near-gas",
@@ -5337,7 +5414,6 @@ dependencies = [
  "near-token",
  "near-vm-runner",
  "once_cell",
- "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
@@ -5391,7 +5467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34de6b54d82d0790b2a56b677e7b4ecb7f021a7e8559f8611065c890d56cfcda"
 dependencies = [
  "borsh 1.6.1",
- "schemars 0.8.22",
  "serde",
 ]
 
@@ -5683,6 +5758,7 @@ name = "omni-connector"
 version = "0.4.0"
 dependencies = [
  "alloy",
+ "aptos-bridge-client",
  "bip0039",
  "bitcoin",
  "borsh 1.6.1",
@@ -5697,7 +5773,7 @@ dependencies = [
  "near-contract-standards",
  "near-crypto",
  "near-jsonrpc-client",
- "near-mpc-contract-interface",
+ "near-mpc-contract-interface 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
  "near-primitives",
  "near-rpc-client",
  "near-sdk",
@@ -5728,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "omni-types"
 version = "3.3.3"
-source = "git+https://github.com/near-one/omni-bridge?rev=ba6d1d4470d8dbe2748280647430ebf06a3cc299#ba6d1d4470d8dbe2748280647430ebf06a3cc299"
+source = "git+https://github.com/near-one/omni-bridge?rev=8c2886043e366bafa810ca3e757f301b8c0df4fc#8c2886043e366bafa810ca3e757f301b8c0df4fc"
 dependencies = [
  "alloy",
  "borsh 1.6.1",
@@ -5741,6 +5817,7 @@ dependencies = [
  "rlp 0.6.1",
  "schemars 0.8.22",
  "serde",
+ "serde_with",
  "sha2 0.10.9",
  "sha3",
  "strum 0.27.2",
@@ -7463,11 +7540,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58 0.5.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7483,9 +7561,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10172,7 +10250,7 @@ version = "0.1.3"
 dependencies = [
  "async-trait",
  "hex",
- "near-mpc-contract-interface",
+ "near-mpc-contract-interface 0.0.1 (git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0)",
  "omni-types",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "bridge-sdk/bridge-clients/wormhole-bridge-client",
     "bridge-sdk/bridge-clients/utxo-bridge-client",
     "bridge-sdk/bridge-clients/starknet-bridge-client",
+    "bridge-sdk/bridge-clients/aptos-bridge-client",
     "bridge-sdk/crypto-utils",
     "bridge-sdk/utxo-utils",
     "bridge-sdk/light-client"
@@ -49,7 +50,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 base64 = "0.22"
 near-token = "0.3"
 near-contract-standards = "5.5"
-omni-types = { git = "https://github.com/near-one/omni-bridge", package = "omni-types", rev = "ba6d1d4470d8dbe2748280647430ebf06a3cc299", features = ["abi", "__abi-generate"] }
+omni-types = { git = "https://github.com/near-one/omni-bridge", package = "omni-types", rev = "8c2886043e366bafa810ca3e757f301b8c0df4fc" }
 starknet = "0.17.0"
 serde_with = { version = "3.12.0", features = ["schemars_0_8"] }
 solana-sdk = "2.0.13"
@@ -61,7 +62,9 @@ spl-token-2022 = { version = "7.0.0", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "6.0.0", features = ["no-entrypoint"] }
 mpl-token-metadata = "5.1.0"
 crypto-shared = { git = "https://github.com/near-one/mpc", package = "crypto-shared", rev = "463172481597ee09b12020b72c61d6b01da7b167" }
-near-mpc-contract-interface = "0.0.1"
+near-mpc-contract-interface = { git = "https://github.com/near/mpc", package = "near-mpc-contract-interface", rev = "dcc9e042cad6784d33cfa736afb61b876a14ded0" }
+bcs = "0.1"
+ed25519-dalek = "2"
 openssl-sys = { version = "*", features = ["vendored"] }
 light-client = { path = "bridge-sdk/light-client" }
 zcash_primitives = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -27,6 +27,7 @@ solana-bridge-client = { path = "../bridge-sdk/bridge-clients/solana-bridge-clie
 wormhole-bridge-client = { path = "../bridge-sdk/bridge-clients/wormhole-bridge-client" }
 utxo-bridge-client = { path = "../bridge-sdk/bridge-clients/utxo-bridge-client" }
 starknet-bridge-client = { path = "../bridge-sdk/bridge-clients/starknet-bridge-client" }
+aptos-bridge-client = { path = "../bridge-sdk/bridge-clients/aptos-bridge-client" }
 utxo-utils = { path = "../bridge-sdk/utxo-utils" }
 near-sdk.workspace = true
 near-mpc-contract-interface.workspace = true

--- a/bridge-cli/src/defaults.rs
+++ b/bridge-cli/src/defaults.rs
@@ -64,6 +64,11 @@ pub const STARKNET_BRIDGE_TOKEN_FACTORY_ADDRESS_MAINNET: &str =
     "0x05f9a4a841dfb7bb3cde33073b2450fe45dcd407fb6c0985a274b0e943ad8598";
 pub const STARKNET_CHAIN_ID_MAINNET: &str = "SN_MAIN";
 
+pub const APTOS_RPC_MAINNET: &str = "https://fullnode.mainnet.aptoslabs.com/v1";
+// TODO: set once the omni_bridge Move package is deployed to Aptos mainnet.
+pub const APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_MAINNET: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
 pub const FOGO_RPC_MAINNET: &str = "https://mainnet.fogo.io";
 pub const FOGO_BRIDGE_ADDRESS_MAINNET: &str = "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe";
 pub const FOGO_WORMHOLE_ADDRESS_MAINNET: &str = "worm2mrQkG1B1KTz37erMfWN8anHkSK24nzca7UD8BB";
@@ -138,6 +143,11 @@ pub const STARKNET_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET: &str =
     "0x02830785fd87b181c5391819f4a5e6a0b2d76c49d92b7f748a2433495eead162";
 pub const STARKNET_CHAIN_ID_TESTNET: &str = "SN_SEPOLIA";
 
+pub const APTOS_RPC_TESTNET: &str = "https://fullnode.testnet.aptoslabs.com/v1";
+// TODO: set once the omni_bridge Move package is deployed to Aptos testnet.
+pub const APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+
 pub const FOGO_RPC_TESTNET: &str = "https://testnet.fogo.io";
 // pub const FOGO_BRIDGE_ADDRESS_TESTNET: &str = "";
 pub const FOGO_WORMHOLE_ADDRESS_TESTNET: &str = "BhnQyKoQQgpuRTRo6D8Emz93PvXCYfVgHhnrR4T3qhw4";
@@ -211,6 +221,11 @@ pub const STARKNET_RPC_DEVNET: &str = "https://starknet-sepolia-rpc.publicnode.c
 pub const STARKNET_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET: &str =
     "0x05a0ad01b18eba34432d22e4cb5c987560cae87a785b494ed58d9553a98bdc8f";
 pub const STARKNET_CHAIN_ID_DEVNET: &str = "SN_SEPOLIA";
+
+pub const APTOS_RPC_DEVNET: &str = "https://fullnode.testnet.aptoslabs.com/v1";
+// TODO: set once the omni_bridge Move package is deployed.
+pub const APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET: &str =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 pub const FOGO_RPC_DEVNET: &str = "https://testnet.fogo.io";
 // pub const FOGO_BRIDGE_ADDRESS_DEVNET: &str = "";

--- a/bridge-cli/src/main.rs
+++ b/bridge-cli/src/main.rs
@@ -156,6 +156,15 @@ struct CliConfig {
     starknet_chain_id: Option<String>,
 
     #[arg(long)]
+    aptos_rpc: Option<String>,
+    #[arg(long)]
+    aptos_private_key: Option<String>,
+    #[arg(long)]
+    aptos_account_address: Option<String>,
+    #[arg(long)]
+    aptos_bridge_address: Option<String>,
+
+    #[arg(long)]
     config: Option<String>,
 }
 
@@ -273,6 +282,11 @@ impl CliConfig {
                 .or(other.starknet_bridge_address),
             starknet_chain_id: self.starknet_chain_id.or(other.starknet_chain_id),
 
+            aptos_rpc: self.aptos_rpc.or(other.aptos_rpc),
+            aptos_private_key: self.aptos_private_key.or(other.aptos_private_key),
+            aptos_account_address: self.aptos_account_address.or(other.aptos_account_address),
+            aptos_bridge_address: self.aptos_bridge_address.or(other.aptos_bridge_address),
+
             config: self.config.or(other.config),
         }
     }
@@ -371,6 +385,11 @@ fn env_config() -> CliConfig {
         starknet_account_address: env::var("STARKNET_ACCOUNT_ADDRESS").ok(),
         starknet_bridge_address: env::var("STARKNET_BRIDGE_ADDRESS").ok(),
         starknet_chain_id: env::var("STARKNET_CHAIN_ID").ok(),
+
+        aptos_rpc: env::var("APTOS_RPC").ok(),
+        aptos_private_key: env::var("APTOS_PRIVATE_KEY").ok(),
+        aptos_account_address: env::var("APTOS_ACCOUNT_ADDRESS").ok(),
+        aptos_bridge_address: env::var("APTOS_BRIDGE_ADDRESS").ok(),
 
         config: None,
     }
@@ -482,6 +501,13 @@ fn default_config(network: Network) -> CliConfig {
             ),
             starknet_chain_id: Some(defaults::STARKNET_CHAIN_ID_MAINNET.to_owned()),
 
+            aptos_rpc: Some(defaults::APTOS_RPC_MAINNET.to_owned()),
+            aptos_private_key: None,
+            aptos_account_address: None,
+            aptos_bridge_address: Some(
+                defaults::APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_MAINNET.to_owned(),
+            ),
+
             config: None,
         },
         Network::Testnet => CliConfig {
@@ -588,6 +614,13 @@ fn default_config(network: Network) -> CliConfig {
             ),
             starknet_chain_id: Some(defaults::STARKNET_CHAIN_ID_TESTNET.to_owned()),
 
+            aptos_rpc: Some(defaults::APTOS_RPC_TESTNET.to_owned()),
+            aptos_private_key: None,
+            aptos_account_address: None,
+            aptos_bridge_address: Some(
+                defaults::APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_TESTNET.to_owned(),
+            ),
+
             config: None,
         },
         Network::Devnet => CliConfig {
@@ -693,6 +726,13 @@ fn default_config(network: Network) -> CliConfig {
                 defaults::STARKNET_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET.to_owned(),
             ),
             starknet_chain_id: Some(defaults::STARKNET_CHAIN_ID_DEVNET.to_owned()),
+
+            aptos_rpc: Some(defaults::APTOS_RPC_DEVNET.to_owned()),
+            aptos_private_key: None,
+            aptos_account_address: None,
+            aptos_bridge_address: Some(
+                defaults::APTOS_BRIDGE_TOKEN_FACTORY_ADDRESS_DEVNET.to_owned(),
+            ),
 
             config: None,
         },

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -1,11 +1,12 @@
 use clap::Subcommand;
 use core::panic;
-use near_mpc_contract_interface::types::{EvmFinality, StarknetFinality};
+use near_mpc_contract_interface::types::{AptosFinality, EvmFinality, StarknetFinality};
 use std::collections::HashMap;
 use std::{path::Path, str::FromStr};
 
 use alloy::primitives::{Address as EvmH160, TxHash};
 use alloy::signers::local::PrivateKeySigner;
+use aptos_bridge_client::AptosBridgeClientBuilder;
 use evm_bridge_client::EvmBridgeClientBuilder;
 use light_client::LightClientBuilder;
 use near_bridge_client::{
@@ -500,6 +501,41 @@ pub enum OmniConnectorSubCommand {
         config_cli: CliConfig,
     },
 
+    #[clap(about = "Initialize a transfer on Aptos")]
+    AptosInitTransfer {
+        #[clap(
+            short,
+            long,
+            help = "Token (Fungible Asset metadata object) address on Aptos"
+        )]
+        token: String,
+        #[clap(short, long, help = "Amount to transfer")]
+        amount: u128,
+        #[clap(short, long, help = "Recipient address on the destination chain")]
+        recipient: OmniAddress,
+        #[clap(short, long, help = "Fee to charge for the transfer")]
+        fee: Option<u128>,
+        #[clap(short, long, help = "Native fee to charge for the transfer")]
+        native_fee: Option<u128>,
+        #[clap(short, long, help = "Additional message")]
+        message: Option<String>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
+    #[clap(about = "Finalize a transfer on Aptos")]
+    AptosFinTransfer {
+        #[clap(
+            short,
+            long,
+            help = "Transaction hash of the sign_transfer call on NEAR"
+        )]
+        tx_hash: String,
+        #[clap(long, help = "Sender ID of the sign_transfer call on NEAR")]
+        sender_id: Option<AccountId>,
+        #[command(flatten)]
+        config_cli: CliConfig,
+    },
+
     #[clap(about = "Initialize an SVM OmniBridge program (Solana or Fogo)")]
     SvmInitialize {
         #[clap(long, help = "SVM chain (sol or fogo)")]
@@ -980,6 +1016,15 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     .await
                     .unwrap();
             }
+            ChainKind::Aptos => {
+                omni_connector(network, config_cli)
+                    .deploy_token(DeployTokenArgs::AptosDeployTokenWithTxHash {
+                        near_tx_hash: CryptoHash::from_str(&tx_hash).expect("Invalid tx_hash"),
+                        sender_id: None,
+                    })
+                    .await
+                    .unwrap();
+            }
             ChainKind::Zcash | ChainKind::Btc => {
                 panic!("DeployToken is not supported for UTXO chains");
             }
@@ -1168,7 +1213,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                         .await
                         .unwrap();
                 }
-                ChainKind::Abs | ChainKind::Strk => {
+                ChainKind::Abs | ChainKind::Strk | ChainKind::Aptos => {
                     connector
                         .fin_transfer(FinTransferArgs::NearFinTransferWithMpcProof {
                             chain_kind: chain,
@@ -1316,6 +1361,47 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
         } => {
             omni_connector(network, config_cli)
                 .fin_transfer(FinTransferArgs::StarknetFinTransferWithTxHash {
+                    near_tx_hash: CryptoHash::from_str(&tx_hash).expect("Invalid tx_hash"),
+                    sender_id,
+                })
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::AptosInitTransfer {
+            token,
+            amount,
+            recipient,
+            fee,
+            native_fee,
+            message,
+            config_cli,
+        } => {
+            let (fee, native_fee) = match (fee, native_fee) {
+                (Some(f), Some(nf)) => (f, nf),
+                (Some(f), None) => (f, 0),
+                (None, Some(nf)) => (0, nf),
+                _ => (0, 0),
+            };
+
+            omni_connector(network, config_cli)
+                .init_transfer(InitTransferArgs::AptosInitTransfer {
+                    token,
+                    amount,
+                    recipient: recipient.to_string(),
+                    fee,
+                    native_fee,
+                    message: message.unwrap_or_default(),
+                })
+                .await
+                .unwrap();
+        }
+        OmniConnectorSubCommand::AptosFinTransfer {
+            tx_hash,
+            sender_id,
+            config_cli,
+        } => {
+            omni_connector(network, config_cli)
+                .fin_transfer(FinTransferArgs::AptosFinTransferWithTxHash {
                     near_tx_hash: CryptoHash::from_str(&tx_hash).expect("Invalid tx_hash"),
                     sender_id,
                 })
@@ -1480,7 +1566,7 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     .await
                     .unwrap();
             }
-            ChainKind::Abs | ChainKind::Strk => {
+            ChainKind::Abs | ChainKind::Strk | ChainKind::Aptos => {
                 omni_connector(network, config_cli)
                     .bind_token(BindTokenArgs::BindTokenWithMpcProofTx {
                         chain_kind: chain,
@@ -2125,6 +2211,15 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .build()
         .unwrap();
 
+    let aptos_bridge_client = AptosBridgeClientBuilder::default()
+        .endpoint(combined_config.aptos_rpc)
+        .private_key(combined_config.aptos_private_key)
+        .account_address(combined_config.aptos_account_address)
+        .omni_bridge_address(combined_config.aptos_bridge_address)
+        .mpc_finality(Some(AptosFinality::Committed))
+        .build()
+        .unwrap();
+
     OmniConnectorBuilder::default()
         .network(Some(network.into()))
         .near_bridge_client(Some(near_bridge_client))
@@ -2138,6 +2233,7 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
         .solana_bridge_client(Some(solana_bridge_client))
         .fogo_bridge_client(Some(fogo_bridge_client))
         .starknet_bridge_client(Some(starknet_bridge_client))
+        .aptos_bridge_client(Some(aptos_bridge_client))
         .wormhole_bridge_client(Some(wormhole_bridge_client))
         .btc_bridge_client(Some(btc_bridge_client))
         .zcash_bridge_client(Some(zcash_bridge_client))

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "aptos-bridge-client"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.88.0"
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace = true
+near-mpc-contract-interface.workspace = true
+omni-types.workspace = true
+hex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+tokio.workspace = true
+bcs.workspace = true
+ed25519-dalek.workspace = true
+sha3.workspace = true
+
+[lib]
+path = "src/aptos_bridge_client.rs"

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/src/aptos_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/src/aptos_bridge_client.rs
@@ -1,0 +1,594 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use ed25519_dalek::SigningKey;
+use near_mpc_contract_interface::types::AptosFinality;
+use omni_types::near_events::OmniBridgeEvent;
+use omni_types::OmniAddress;
+
+use crate::error::{AptosBridgeClientError, Result};
+use crate::rest::{CommittedTransaction, TransactionEvent};
+use crate::transaction::{args, EntryFunction, ModuleId, RawTransaction, TransactionPayload};
+
+pub use builder::AptosBridgeClientBuilder;
+
+mod builder;
+pub mod error;
+mod rest;
+mod transaction;
+
+/// Move module that hosts the bridge entry functions.
+const MODULE_NAME: &str = "omni_bridge";
+/// Generous upper bound; omni-bridge entry functions cost well under this.
+const MAX_GAS_AMOUNT: u64 = 100_000;
+/// How long a submitted transaction stays valid for inclusion.
+const TX_EXPIRATION_SECS: u64 = 60;
+/// Receipt polling after submission.
+const MAX_POLL_RETRIES: u32 = 30;
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// An Ed25519 signing identity for submitting Aptos transactions.
+pub struct AptosAccount {
+    pub(crate) signing_key: SigningKey,
+    pub(crate) address: [u8; 32],
+}
+
+/// Aptos bridge client for the `omni_bridge` Move package.
+pub struct AptosBridgeClient {
+    pub(crate) http_client: reqwest::Client,
+    pub(crate) base_url: String,
+    pub(crate) account: Option<AptosAccount>,
+    pub(crate) omni_bridge_address: Option<[u8; 32]>,
+    pub(crate) mpc_finality: Option<AptosFinality>,
+}
+
+/// A decoded `InitTransfer` event, used to derive NEAR storage-deposit actions.
+#[derive(Debug)]
+pub struct AptosInitTransferEvent {
+    pub sender: [u8; 32],
+    pub token_address: [u8; 32],
+    pub origin_nonce: u64,
+    pub amount: u128,
+    pub fee: u128,
+    pub native_fee: u128,
+    pub recipient: String,
+    pub message: String,
+}
+
+/// A raw bridge event with the metadata the MPC foreign-tx validation payload
+/// needs. `data` and `account_address` are already in the canonical form the
+/// MPC node reconstructs (see `normalize_event_data` / left-padded address).
+#[derive(Debug)]
+pub struct AptosEventLog {
+    pub account_address: [u8; 32],
+    pub sequence_number: u64,
+    pub type_tag: String,
+    pub data: String,
+    pub event_index: u64,
+}
+
+impl AptosBridgeClient {
+    fn account(&self) -> Result<&AptosAccount> {
+        self.account.as_ref().ok_or_else(|| {
+            AptosBridgeClientError::ConfigError(
+                "Aptos private key / account address is not set".to_string(),
+            )
+        })
+    }
+
+    fn omni_bridge_address(&self) -> Result<[u8; 32]> {
+        self.omni_bridge_address.ok_or_else(|| {
+            AptosBridgeClientError::ConfigError("OmniBridge address is not set".to_string())
+        })
+    }
+
+    fn bridge_module(&self) -> Result<ModuleId> {
+        Ok(ModuleId {
+            address: transaction::AccountAddress(self.omni_bridge_address()?),
+            name: MODULE_NAME.to_string(),
+        })
+    }
+
+    /// Build, sign, and submit an `omni_bridge` entry-function call, then wait
+    /// for it to commit. Returns the transaction hash (`0x`-prefixed).
+    async fn submit_entry_function(&self, function: &str, args: Vec<Vec<u8>>) -> Result<String> {
+        let account = self.account()?;
+        let module = self.bridge_module()?;
+
+        let sender_hex = format!("0x{}", hex::encode(account.address));
+        let sequence_number =
+            rest::get_account_sequence_number(&self.http_client, &self.base_url, &sender_hex)
+                .await?;
+        let chain_id = rest::get_ledger_info(&self.http_client, &self.base_url)
+            .await?
+            .chain_id;
+        let gas_unit_price = rest::estimate_gas_price(&self.http_client, &self.base_url).await?;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| AptosBridgeClientError::TransactionError(format!("system clock: {e}")))?
+            .as_secs();
+
+        let raw_txn = RawTransaction {
+            sender: transaction::AccountAddress(account.address),
+            sequence_number,
+            payload: TransactionPayload::EntryFunction(EntryFunction {
+                module,
+                function: function.to_string(),
+                ty_args: Vec::new(),
+                args,
+            }),
+            max_gas_amount: MAX_GAS_AMOUNT,
+            gas_unit_price,
+            expiration_timestamp_secs: now + TX_EXPIRATION_SECS,
+            chain_id,
+        };
+
+        let signed = raw_txn.sign(&account.signing_key).map_err(|e| {
+            AptosBridgeClientError::TransactionError(format!("failed to sign transaction: {e}"))
+        })?;
+        let signed_bytes = bcs::to_bytes(&signed).map_err(|e| {
+            AptosBridgeClientError::TransactionError(format!(
+                "failed to serialize signed transaction: {e}"
+            ))
+        })?;
+
+        let tx_hash =
+            rest::submit_bcs_transaction(&self.http_client, &self.base_url, signed_bytes).await?;
+        tracing::info!(tx_hash = %tx_hash, "Submitted Aptos transaction");
+        self.wait_for_committed(&tx_hash).await?;
+        Ok(tx_hash)
+    }
+
+    async fn wait_for_committed(&self, tx_hash: &str) -> Result<()> {
+        for _ in 0..MAX_POLL_RETRIES {
+            if let Some(tx) =
+                rest::get_transaction_by_hash(&self.http_client, &self.base_url, tx_hash).await?
+            {
+                match tx.success {
+                    Some(true) => return Ok(()),
+                    Some(false) => {
+                        return Err(AptosBridgeClientError::TransactionError(format!(
+                            "transaction {tx_hash} failed: {}",
+                            tx.vm_status.unwrap_or_default()
+                        )));
+                    }
+                    None => {}
+                }
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+        Err(AptosBridgeClientError::TransactionError(format!(
+            "transaction {tx_hash} was not committed after {} seconds",
+            u64::from(MAX_POLL_RETRIES) * POLL_INTERVAL.as_secs()
+        )))
+    }
+
+    /// Log token metadata on the Aptos `omni_bridge` contract (permissionless).
+    #[tracing::instrument(skip_all, name = "APTOS LOG METADATA")]
+    pub async fn log_metadata(&self, token: [u8; 32]) -> Result<String> {
+        self.submit_entry_function("log_metadata", vec![args::address(token)])
+            .await
+    }
+
+    /// Deploy a bridged token on Aptos using a `LogMetadataEvent` from NEAR.
+    #[tracing::instrument(skip_all, name = "APTOS DEPLOY TOKEN")]
+    pub async fn deploy_token(&self, event: OmniBridgeEvent) -> Result<String> {
+        let OmniBridgeEvent::LogMetadataEvent {
+            signature,
+            metadata_payload,
+        } = event
+        else {
+            return Err(AptosBridgeClientError::InvalidArgument(format!(
+                "Expected LogMetadataEvent but got {event:?}"
+            )));
+        };
+
+        let (rs, v) = split_signature(&signature.to_bytes())?;
+
+        self.submit_entry_function(
+            "deploy_token",
+            vec![
+                args::bytes(&rs),
+                args::u8(v),
+                args::string(&metadata_payload.token),
+                args::string(&metadata_payload.name),
+                args::string(&metadata_payload.symbol),
+                args::u8(metadata_payload.decimals),
+            ],
+        )
+        .await
+    }
+
+    /// Initiate a transfer from Aptos to another chain (user-signed outbound).
+    #[tracing::instrument(skip_all, name = "APTOS INIT TRANSFER")]
+    pub async fn init_transfer(
+        &self,
+        token: [u8; 32],
+        amount: u128,
+        fee: u128,
+        native_fee: u128,
+        recipient: String,
+        message: Vec<u8>,
+    ) -> Result<String> {
+        self.submit_entry_function(
+            "init_transfer",
+            vec![
+                args::address(token),
+                args::u128(amount),
+                args::u128(fee),
+                args::u128(native_fee),
+                args::string(&recipient),
+                args::bytes(&message),
+            ],
+        )
+        .await
+    }
+
+    /// Finalize a transfer to Aptos using a `SignTransferEvent` from NEAR.
+    #[tracing::instrument(skip_all, name = "APTOS FIN TRANSFER")]
+    pub async fn fin_transfer(&self, event: OmniBridgeEvent) -> Result<String> {
+        let OmniBridgeEvent::SignTransferEvent {
+            message_payload,
+            signature,
+        } = event
+        else {
+            return Err(AptosBridgeClientError::InvalidArgument(format!(
+                "Expected SignTransferEvent but got {event:?}"
+            )));
+        };
+
+        let (rs, v) = split_signature(&signature.to_bytes())?;
+        let token = omni_address_to_aptos(&message_payload.token_address)?;
+        let recipient = omni_address_to_aptos(&message_payload.recipient)?;
+        let amount: u128 = message_payload.amount.into();
+        let fee_recipient = message_payload.fee_recipient.map(|a| a.to_string());
+        let message = if message_payload.message.is_empty() {
+            None
+        } else {
+            Some(message_payload.message)
+        };
+
+        self.submit_entry_function(
+            "fin_transfer",
+            vec![
+                args::bytes(&rs),
+                args::u8(v),
+                args::u64(message_payload.destination_nonce),
+                args::u8(u8::from(message_payload.transfer_id.origin_chain)),
+                args::u64(message_payload.transfer_id.origin_nonce),
+                args::address(token),
+                args::u128(amount),
+                args::address(recipient),
+                args::option_string(fee_recipient.as_deref()),
+                args::option_bytes(message.as_deref()),
+            ],
+        )
+        .await
+    }
+
+    /// Whether a transfer with the given destination nonce has been finalised.
+    pub async fn is_transfer_finalised(&self, nonce: u64) -> Result<bool> {
+        let bridge = self.omni_bridge_address()?;
+        let function = format!(
+            "0x{}::{MODULE_NAME}::is_transfer_finalised",
+            hex::encode(bridge)
+        );
+        let result = rest::view(
+            &self.http_client,
+            &self.base_url,
+            &function,
+            Vec::new(),
+            vec![serde_json::json!(nonce.to_string())],
+        )
+        .await?;
+        result
+            .first()
+            .and_then(serde_json::Value::as_bool)
+            .ok_or_else(|| {
+                AptosBridgeClientError::BlockchainDataError(
+                    "is_transfer_finalised view returned no boolean".to_string(),
+                )
+            })
+    }
+
+    /// Returns the configured MPC finality level for this chain.
+    pub fn mpc_finality(&self) -> Result<AptosFinality> {
+        self.mpc_finality.clone().ok_or_else(|| {
+            AptosBridgeClientError::ConfigError("MPC finality is not configured".to_string())
+        })
+    }
+
+    /// Verifies that `tx_hash` has reached the configured MPC finality level
+    /// and returns it for embedding in the MPC sign payload. For Aptos,
+    /// `Committed` means the transaction carries a successful execution result.
+    pub async fn check_mpc_finality(&self, tx_hash: &str) -> Result<AptosFinality> {
+        let finality = self.mpc_finality()?;
+        match rest::get_transaction_by_hash(&self.http_client, &self.base_url, tx_hash).await? {
+            Some(tx) => match tx.success {
+                Some(true) => Ok(finality),
+                Some(false) => Err(AptosBridgeClientError::TransactionError(format!(
+                    "transaction {tx_hash} failed: {}",
+                    tx.vm_status.unwrap_or_default()
+                ))),
+                None => Err(AptosBridgeClientError::MpcFinalityNotReached),
+            },
+            None => Err(AptosBridgeClientError::MpcFinalityNotReached),
+        }
+    }
+
+    /// Decode the `InitTransfer` event from a transaction.
+    pub async fn get_transfer_event(&self, tx_hash: &str) -> Result<AptosInitTransferEvent> {
+        let tx = self.fetch_committed(tx_hash).await?;
+        let (_, event) = find_bridge_event(&tx, self.omni_bridge_address()?, "InitTransfer")?;
+        parse_init_transfer_event(&event.data)
+    }
+
+    /// Raw `InitTransfer` log with metadata for MPC proof construction.
+    pub async fn get_init_transfer_log(&self, tx_hash: &str) -> Result<AptosEventLog> {
+        self.get_event_log(tx_hash, "InitTransfer").await
+    }
+
+    /// Raw `DeployToken` log with metadata for MPC proof construction.
+    pub async fn get_deploy_token_log(&self, tx_hash: &str) -> Result<AptosEventLog> {
+        self.get_event_log(tx_hash, "DeployToken").await
+    }
+
+    /// Raw `FinTransfer` log with metadata for MPC proof construction.
+    pub async fn get_fin_transfer_log(&self, tx_hash: &str) -> Result<AptosEventLog> {
+        self.get_event_log(tx_hash, "FinTransfer").await
+    }
+
+    async fn fetch_committed(&self, tx_hash: &str) -> Result<CommittedTransaction> {
+        rest::get_transaction_by_hash(&self.http_client, &self.base_url, tx_hash)
+            .await?
+            .ok_or_else(|| {
+                AptosBridgeClientError::BlockchainDataError(format!(
+                    "transaction {tx_hash} not found"
+                ))
+            })
+    }
+
+    async fn get_event_log(&self, tx_hash: &str, event_name: &str) -> Result<AptosEventLog> {
+        let bridge = self.omni_bridge_address()?;
+        let tx = self.fetch_committed(tx_hash).await?;
+        let (event_index, event) = find_bridge_event(&tx, bridge, event_name)?;
+
+        let account_address = builder::parse_address(&event.guid.account_address).map_err(|e| {
+            AptosBridgeClientError::BlockchainDataError(format!(
+                "invalid event account_address: {e}"
+            ))
+        })?;
+        let sequence_number = event.sequence_number.parse().map_err(|e| {
+            AptosBridgeClientError::BlockchainDataError(format!(
+                "invalid event sequence_number {:?}: {e}",
+                event.sequence_number
+            ))
+        })?;
+
+        Ok(AptosEventLog {
+            account_address,
+            sequence_number,
+            type_tag: event.event_type.clone(),
+            data: normalize_event_data(&event.data),
+            event_index: u64::try_from(event_index).map_err(|_| {
+                AptosBridgeClientError::BlockchainDataError("event index exceeds u64".to_string())
+            })?,
+        })
+    }
+}
+
+/// Parse an Aptos address from hex (0x-prefixed, short forms left-padded to 32
+/// bytes). Exposed so callers can turn a config/CLI address string into the
+/// 32-byte form the entry-function helpers expect.
+pub fn parse_account_address(s: &str) -> std::result::Result<[u8; 32], String> {
+    builder::parse_address(s)
+}
+
+/// Split a 65-byte Ethereum-style signature into `(r||s, v)`.
+fn split_signature(sig: &[u8]) -> Result<(Vec<u8>, u8)> {
+    let sig: [u8; 65] = sig.try_into().map_err(|_| {
+        AptosBridgeClientError::InvalidArgument("Signature must be 65 bytes".to_string())
+    })?;
+    Ok((sig[..64].to_vec(), sig[64]))
+}
+
+fn omni_address_to_aptos(address: &OmniAddress) -> Result<[u8; 32]> {
+    match address {
+        OmniAddress::Aptos(h256) => Ok(h256.0),
+        other => Err(AptosBridgeClientError::InvalidArgument(format!(
+            "Expected Aptos address but got {other:?}"
+        ))),
+    }
+}
+
+/// Split a Move event type tag `0xaddr::module::Struct` into its parts.
+fn parse_event_type(event_type: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = event_type.splitn(3, "::");
+    let address = parts.next()?;
+    let module = parts.next()?;
+    let name = parts.next()?;
+    Some((address, module, name))
+}
+
+/// Find the `omni_bridge::{event_name}` event emitted by `bridge`, with its
+/// index in the transaction's `events` array.
+fn find_bridge_event<'a>(
+    tx: &'a CommittedTransaction,
+    bridge: [u8; 32],
+    event_name: &str,
+) -> Result<(usize, &'a TransactionEvent)> {
+    tx.events
+        .iter()
+        .enumerate()
+        .find(|(_, event)| {
+            parse_event_type(&event.event_type).is_some_and(|(address, module, name)| {
+                module == MODULE_NAME
+                    && name == event_name
+                    && builder::parse_address(address).is_ok_and(|addr| addr == bridge)
+            })
+        })
+        .ok_or_else(|| {
+            AptosBridgeClientError::BlockchainDataError(format!(
+                "{event_name} event not found in transaction {}",
+                tx.hash
+            ))
+        })
+}
+
+fn parse_init_transfer_event(data: &serde_json::Value) -> Result<AptosInitTransferEvent> {
+    let str_field = |key: &str| -> Result<&str> {
+        data.get(key)
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                AptosBridgeClientError::BlockchainDataError(format!(
+                    "InitTransfer event missing string field {key}"
+                ))
+            })
+    };
+    let address = |key: &str| -> Result<[u8; 32]> {
+        builder::parse_address(str_field(key)?).map_err(|e| {
+            AptosBridgeClientError::BlockchainDataError(format!("InitTransfer {key}: {e}"))
+        })
+    };
+    let u64_field = |key: &str| -> Result<u64> {
+        str_field(key)?.parse().map_err(|e| {
+            AptosBridgeClientError::BlockchainDataError(format!("InitTransfer {key}: {e}"))
+        })
+    };
+    let u128_field = |key: &str| -> Result<u128> {
+        str_field(key)?.parse().map_err(|e| {
+            AptosBridgeClientError::BlockchainDataError(format!("InitTransfer {key}: {e}"))
+        })
+    };
+
+    Ok(AptosInitTransferEvent {
+        sender: address("sender")?,
+        token_address: address("token_address")?,
+        origin_nonce: u64_field("origin_nonce")?,
+        amount: u128_field("amount")?,
+        fee: u128_field("fee")?,
+        native_fee: u128_field("native_fee")?,
+        recipient: str_field("recipient")?.to_string(),
+        message: decode_message(str_field("message")?),
+    })
+}
+
+/// Decode an event `vector<u8>` field (`0x…` hex) to text. Bridge messages
+/// carry UTF-8; keep the raw hex string if the bytes aren't valid UTF-8.
+fn decode_message(hex_str: &str) -> String {
+    let stripped = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    if stripped.is_empty() {
+        return String::new();
+    }
+    hex::decode(stripped)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .unwrap_or_else(|| hex_str.to_string())
+}
+
+/// Canonical string form of an event's `data`: object keys sorted recursively
+/// so the MPC node and the SDK hash identical bytes regardless of provider key
+/// ordering. Byte-for-byte mirror of the node's `normalize_event_data`.
+pub fn normalize_event_data(value: &serde_json::Value) -> String {
+    serde_json::to_string(&sort_keys(value.clone()))
+        .expect("serde_json serialization of Value is infallible")
+}
+
+fn sort_keys(v: serde_json::Value) -> serde_json::Value {
+    match v {
+        serde_json::Value::Object(map) => {
+            let sorted: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .map(|(k, v)| (k, sort_keys(v)))
+                .collect::<BTreeMap<_, _>>()
+                .into_iter()
+                .collect();
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(sort_keys).collect())
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_event_data_sorts_keys_recursively() {
+        let value = serde_json::json!({ "z": 1, "a": 2, "nested": { "y": 1, "x": 2 } });
+        assert_eq!(
+            normalize_event_data(&value),
+            r#"{"a":2,"nested":{"x":2,"y":1},"z":1}"#
+        );
+    }
+
+    #[test]
+    fn split_signature_splits_rs_and_v() {
+        let mut sig = [0u8; 65];
+        sig[0] = 0xAA;
+        sig[63] = 0xBB;
+        sig[64] = 27;
+        let (rs, v) = split_signature(&sig).unwrap();
+        assert_eq!(rs.len(), 64);
+        assert_eq!(rs[0], 0xAA);
+        assert_eq!(rs[63], 0xBB);
+        assert_eq!(v, 27);
+        assert!(split_signature(&[0u8; 64]).is_err());
+    }
+
+    #[test]
+    fn parse_event_type_splits_parts() {
+        assert_eq!(
+            parse_event_type("0xcafe::omni_bridge::InitTransfer"),
+            Some(("0xcafe", "omni_bridge", "InitTransfer"))
+        );
+        assert_eq!(parse_event_type("not-a-type"), None);
+    }
+
+    #[test]
+    fn find_bridge_event_matches_module_and_name() {
+        let tx: CommittedTransaction = serde_json::from_value(serde_json::json!({
+            "hash": "0xabc",
+            "success": true,
+            "events": [
+                { "guid": {"account_address": "0x0"}, "sequence_number": "0",
+                  "type": "0x1::other::InitTransfer", "data": {} },
+                { "guid": {"account_address": "0x0"}, "sequence_number": "5",
+                  "type": "0xcafe::omni_bridge::InitTransfer", "data": {"amount": "1"} }
+            ]
+        }))
+        .unwrap();
+        // 0xcafe left-padded to 32 bytes.
+        let mut bridge = [0u8; 32];
+        bridge[30] = 0xca;
+        bridge[31] = 0xfe;
+        let (idx, event) = find_bridge_event(&tx, bridge, "InitTransfer").unwrap();
+        assert_eq!(idx, 1);
+        assert_eq!(event.sequence_number, "5");
+    }
+
+    #[test]
+    fn parse_init_transfer_event_decodes_fields() {
+        let data = serde_json::json!({
+            "sender": "0xabc",
+            "token_address": "0xa",
+            "origin_nonce": "7",
+            "amount": "1000000",
+            "fee": "100",
+            "native_fee": "50",
+            "recipient": "near:alice.near",
+            "message": "0x"
+        });
+        let event = parse_init_transfer_event(&data).unwrap();
+        assert_eq!(event.origin_nonce, 7);
+        assert_eq!(event.amount, 1_000_000);
+        assert_eq!(event.fee, 100);
+        assert_eq!(event.native_fee, 50);
+        assert_eq!(event.recipient, "near:alice.near");
+        assert_eq!(event.token_address[31], 0x0a);
+    }
+}

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/src/builder.rs
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/src/builder.rs
@@ -1,0 +1,143 @@
+use ed25519_dalek::SigningKey;
+use near_mpc_contract_interface::types::AptosFinality;
+
+use crate::error::{AptosBridgeClientError, Result};
+use crate::{AptosAccount, AptosBridgeClient};
+
+#[derive(Default)]
+pub struct AptosBridgeClientBuilder {
+    #[doc = r"Required. Aptos fullnode REST endpoint, including the `/v1` segment."]
+    endpoint: Option<String>,
+    #[doc = r"Optional. Hex-encoded 32-byte Ed25519 private key (seed) for signing transactions."]
+    private_key: Option<String>,
+    #[doc = r"Optional. Aptos account address (32-byte hex) matching the private key."]
+    account_address: Option<String>,
+    #[doc = r"Optional. Account the `omni_bridge` Move package is published under (32-byte hex)."]
+    omni_bridge_address: Option<String>,
+    #[doc = r"Optional. MPC finality level required before an MPC sign payload can be built."]
+    mpc_finality: Option<AptosFinality>,
+}
+
+impl AptosBridgeClientBuilder {
+    #[must_use]
+    pub fn endpoint(mut self, endpoint: Option<String>) -> Self {
+        self.endpoint = endpoint;
+        self
+    }
+
+    #[must_use]
+    pub fn private_key(mut self, private_key: Option<String>) -> Self {
+        self.private_key = private_key;
+        self
+    }
+
+    #[must_use]
+    pub fn account_address(mut self, account_address: Option<String>) -> Self {
+        self.account_address = account_address;
+        self
+    }
+
+    #[must_use]
+    pub fn omni_bridge_address(mut self, omni_bridge_address: Option<String>) -> Self {
+        self.omni_bridge_address = omni_bridge_address;
+        self
+    }
+
+    #[must_use]
+    pub fn mpc_finality(mut self, mpc_finality: Option<AptosFinality>) -> Self {
+        self.mpc_finality = mpc_finality;
+        self
+    }
+
+    pub fn build(self) -> Result<AptosBridgeClient> {
+        let base_url = self.endpoint.ok_or_else(|| {
+            AptosBridgeClientError::ConfigError("endpoint is required".to_string())
+        })?;
+
+        let account = if let (Some(pk), Some(addr)) = (self.private_key, self.account_address) {
+            let seed = parse_seed(&pk)?;
+            let address = parse_address(&addr).map_err(|e| {
+                AptosBridgeClientError::ConfigError(format!("Invalid Aptos account address: {e}"))
+            })?;
+            Some(AptosAccount {
+                signing_key: SigningKey::from_bytes(&seed),
+                address,
+            })
+        } else {
+            None
+        };
+
+        let omni_bridge_address = self
+            .omni_bridge_address
+            .map(|addr| {
+                parse_address(&addr).map_err(|e| {
+                    AptosBridgeClientError::ConfigError(format!(
+                        "Invalid Aptos bridge address: {e}"
+                    ))
+                })
+            })
+            .transpose()?;
+
+        Ok(AptosBridgeClient {
+            http_client: reqwest::Client::new(),
+            base_url,
+            account,
+            omni_bridge_address,
+            mpc_finality: self.mpc_finality,
+        })
+    }
+}
+
+/// Parse a 32-byte Ed25519 seed from hex (exactly 32 bytes, no padding).
+fn parse_seed(s: &str) -> Result<[u8; 32]> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(s).map_err(|e| {
+        AptosBridgeClientError::ConfigError(format!("Invalid Aptos private key: {e}"))
+    })?;
+    bytes.try_into().map_err(|_| {
+        AptosBridgeClientError::ConfigError(
+            "Aptos private key must be a 32-byte Ed25519 seed".to_string(),
+        )
+    })
+}
+
+/// Parse an Aptos address from hex, left-zero-padding short forms (e.g. "0x1")
+/// to 32 bytes — matching the node-side `parse_aptos_address`.
+pub(crate) fn parse_address(s: &str) -> std::result::Result<[u8; 32], String> {
+    let hex_str = s.strip_prefix("0x").unwrap_or(s);
+    if hex_str.is_empty() {
+        return Err(format!("empty Aptos address: {s:?}"));
+    }
+    if hex_str.len() > 64 {
+        return Err(format!("address hex string too long: {s}"));
+    }
+    let padded = format!("{hex_str:0>64}");
+    let bytes = hex::decode(&padded).map_err(|e| format!("invalid hex in address '{s}': {e}"))?;
+    bytes
+        .try_into()
+        .map_err(|_| "address did not decode to 32 bytes".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_left_pads_short_form() {
+        let mut expected = [0u8; 32];
+        expected[31] = 0x01;
+        assert_eq!(parse_address("0x1").unwrap(), expected);
+        assert_eq!(parse_address("0xa").unwrap()[31], 0x0a);
+    }
+
+    #[test]
+    fn parse_address_rejects_too_long() {
+        assert!(parse_address(&format!("0x{}", "0".repeat(65))).is_err());
+    }
+
+    #[test]
+    fn parse_seed_requires_32_bytes() {
+        assert!(parse_seed(&format!("0x{}", "11".repeat(32))).is_ok());
+        assert!(parse_seed("0x1122").is_err());
+    }
+}

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/src/error.rs
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/src/error.rs
@@ -1,0 +1,17 @@
+pub(crate) type Result<T> = std::result::Result<T, AptosBridgeClientError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AptosBridgeClientError {
+    #[error("Aptos REST error: {0}")]
+    RestError(String),
+    #[error("Aptos transaction error: {0}")]
+    TransactionError(String),
+    #[error("Blockchain data error: {0}")]
+    BlockchainDataError(String),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("Transaction has not reached the required MPC finality")]
+    MpcFinalityNotReached,
+}

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/src/rest.rs
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/src/rest.rs
@@ -1,0 +1,207 @@
+//! Thin wrappers over the Aptos fullnode REST API (v1). The `base_url` is
+//! expected to already include the `/v1` version segment.
+
+use serde::Deserialize;
+
+use crate::error::{AptosBridgeClientError, Result};
+
+/// `GET /v1` — node ledger info. Used for the network chain id.
+#[derive(Debug, Deserialize)]
+pub struct LedgerInfo {
+    pub chain_id: u8,
+}
+
+/// `GET /v1/accounts/{address}` — the bits we need to build a transaction.
+#[derive(Debug, Deserialize)]
+pub struct AccountInfo {
+    pub sequence_number: String,
+}
+
+/// `GET /v1/estimate_gas_price`.
+#[derive(Debug, Deserialize)]
+pub struct GasEstimate {
+    pub gas_estimate: u64,
+}
+
+/// `POST /v1/transactions` (pending tx) response — we only need the hash.
+#[derive(Debug, Deserialize)]
+pub struct PendingTransaction {
+    pub hash: String,
+}
+
+/// `GET /v1/transactions/by_hash/{hash}`. Modelled leniently: `success` is
+/// `Some` only once the transaction is committed (a pending tx omits it).
+#[derive(Debug, Deserialize)]
+pub struct CommittedTransaction {
+    pub hash: String,
+    #[serde(default)]
+    pub success: Option<bool>,
+    #[serde(default)]
+    pub vm_status: Option<String>,
+    #[serde(default)]
+    pub events: Vec<TransactionEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TransactionEvent {
+    pub guid: EventGuid,
+    pub sequence_number: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventGuid {
+    pub account_address: String,
+}
+
+fn trim_base(base_url: &str) -> &str {
+    base_url.trim_end_matches('/')
+}
+
+async fn error_body(response: reqwest::Response) -> AptosBridgeClientError {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    AptosBridgeClientError::RestError(format!("HTTP {status}: {body}"))
+}
+
+pub async fn get_ledger_info(client: &reqwest::Client, base_url: &str) -> Result<LedgerInfo> {
+    let response = client
+        .get(trim_base(base_url))
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("ledger info request: {e}")))?;
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("ledger info decode: {e}")))
+}
+
+pub async fn get_account_sequence_number(
+    client: &reqwest::Client,
+    base_url: &str,
+    address_hex: &str,
+) -> Result<u64> {
+    let url = format!("{}/accounts/{address_hex}", trim_base(base_url));
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("account request: {e}")))?;
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    let info: AccountInfo = response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("account decode: {e}")))?;
+    info.sequence_number.parse().map_err(|e| {
+        AptosBridgeClientError::BlockchainDataError(format!(
+            "invalid account sequence_number {:?}: {e}",
+            info.sequence_number
+        ))
+    })
+}
+
+pub async fn estimate_gas_price(client: &reqwest::Client, base_url: &str) -> Result<u64> {
+    let url = format!("{}/estimate_gas_price", trim_base(base_url));
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("gas price request: {e}")))?;
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    let estimate: GasEstimate = response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("gas price decode: {e}")))?;
+    Ok(estimate.gas_estimate)
+}
+
+/// Submit a BCS-serialized `SignedTransaction`; returns the transaction hash.
+pub async fn submit_bcs_transaction(
+    client: &reqwest::Client,
+    base_url: &str,
+    signed_txn_bcs: Vec<u8>,
+) -> Result<String> {
+    let url = format!("{}/transactions", trim_base(base_url));
+    let response = client
+        .post(&url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x.aptos.signed_transaction+bcs",
+        )
+        .body(signed_txn_bcs)
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("submit request: {e}")))?;
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    let pending: PendingTransaction = response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("submit decode: {e}")))?;
+    Ok(pending.hash)
+}
+
+/// `GET /v1/transactions/by_hash/{hash}`. Returns `Ok(None)` on 404 (not yet
+/// indexed / pending), `Err` on other failures.
+pub async fn get_transaction_by_hash(
+    client: &reqwest::Client,
+    base_url: &str,
+    tx_hash: &str,
+) -> Result<Option<CommittedTransaction>> {
+    let url = format!("{}/transactions/by_hash/{tx_hash}", trim_base(base_url));
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("by_hash request: {e}")))?;
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    let tx = response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("by_hash decode: {e}")))?;
+    Ok(Some(tx))
+}
+
+/// `POST /v1/view` — call a Move view function. Returns the JSON result array.
+pub async fn view(
+    client: &reqwest::Client,
+    base_url: &str,
+    function: &str,
+    type_arguments: Vec<String>,
+    arguments: Vec<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>> {
+    let url = format!("{}/view", trim_base(base_url));
+    let body = serde_json::json!({
+        "function": function,
+        "type_arguments": type_arguments,
+        "arguments": arguments,
+    });
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("view request: {e}")))?;
+    if !response.status().is_success() {
+        return Err(error_body(response).await);
+    }
+    response
+        .json()
+        .await
+        .map_err(|e| AptosBridgeClientError::RestError(format!("view decode: {e}")))
+}

--- a/bridge-sdk/bridge-clients/aptos-bridge-client/src/transaction.rs
+++ b/bridge-sdk/bridge-clients/aptos-bridge-client/src/transaction.rs
@@ -1,0 +1,311 @@
+//! Minimal Aptos transaction model and BCS encoding needed to sign and submit
+//! entry-function calls. Mirrors the layout of `aptos-core`'s
+//! `aptos_types::transaction` so the BCS bytes (and therefore the signing
+//! message) are byte-identical, without depending on the heavy `aptos-sdk`.
+
+use ed25519_dalek::{Signer, SigningKey};
+use serde::Serialize;
+use sha3::{Digest, Sha3_256};
+
+/// A 32-byte Aptos account / object address. Serializes as 32 raw bytes (no
+/// length prefix), matching `aptos_types::account_address::AccountAddress`.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct AccountAddress(pub [u8; 32]);
+
+/// `aptos_types::transaction::Module`-id: the on-chain module a call targets.
+#[derive(Clone, Debug, Serialize)]
+pub struct ModuleId {
+    pub address: AccountAddress,
+    /// Module name as a Move `Identifier` (BCS string).
+    pub name: String,
+}
+
+/// Move type arguments. The omni-bridge entry functions take none, so this is
+/// always empty; the variants exist only to give the empty `Vec` a faithful
+/// element type and are never constructed.
+#[allow(dead_code)]
+#[derive(Clone, Debug, Serialize)]
+pub enum TypeTag {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Signer,
+    Vector(Box<TypeTag>),
+    Struct(Box<StructTag>),
+    U16,
+    U32,
+    U256,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Serialize)]
+pub struct StructTag {
+    pub address: AccountAddress,
+    pub module: String,
+    pub name: String,
+    pub type_args: Vec<TypeTag>,
+}
+
+/// `aptos_types::transaction::EntryFunction`. Each entry in `args` is the
+/// independently BCS-encoded bytes of one Move argument.
+#[derive(Clone, Debug, Serialize)]
+pub struct EntryFunction {
+    pub module: ModuleId,
+    pub function: String,
+    pub ty_args: Vec<TypeTag>,
+    pub args: Vec<Vec<u8>>,
+}
+
+/// `aptos_types::transaction::TransactionPayload`. Only the `EntryFunction`
+/// variant (index 2) is used; `Script`/`ModuleBundle` exist solely to pin the
+/// BCS variant index of `EntryFunction` to 2.
+#[derive(Clone, Debug, Serialize)]
+pub enum TransactionPayload {
+    #[allow(dead_code)]
+    Script,
+    #[allow(dead_code)]
+    ModuleBundle,
+    EntryFunction(EntryFunction),
+}
+
+/// `aptos_types::transaction::RawTransaction`. Field order is significant: it
+/// defines the BCS bytes that get signed.
+#[derive(Clone, Debug, Serialize)]
+pub struct RawTransaction {
+    pub sender: AccountAddress,
+    pub sequence_number: u64,
+    pub payload: TransactionPayload,
+    pub max_gas_amount: u64,
+    pub gas_unit_price: u64,
+    pub expiration_timestamp_secs: u64,
+    pub chain_id: u8,
+}
+
+/// `aptos_types::transaction::authenticator::TransactionAuthenticator`. Only
+/// the single-signer Ed25519 variant (index 0) is used. `public_key` and
+/// `signature` serialize as length-prefixed byte strings, exactly like
+/// aptos's `Ed25519PublicKey`/`Ed25519Signature`.
+#[derive(Clone, Debug, Serialize)]
+pub enum TransactionAuthenticator {
+    Ed25519 {
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SignedTransaction {
+    pub raw_txn: RawTransaction,
+    pub authenticator: TransactionAuthenticator,
+}
+
+/// The salt aptos prepends to a `RawTransaction`'s BCS bytes before signing,
+/// `sha3_256("APTOS::RawTransaction")`.
+fn raw_transaction_signing_salt() -> [u8; 32] {
+    let mut hasher = Sha3_256::new();
+    hasher.update(b"APTOS::RawTransaction");
+    hasher.finalize().into()
+}
+
+impl RawTransaction {
+    /// The bytes that are signed: `sha3_256("APTOS::RawTransaction") || bcs(self)`.
+    pub fn signing_message(&self) -> Result<Vec<u8>, bcs::Error> {
+        let mut message = raw_transaction_signing_salt().to_vec();
+        message.extend(bcs::to_bytes(self)?);
+        Ok(message)
+    }
+
+    /// Sign with an Ed25519 key and wrap into a submittable `SignedTransaction`.
+    pub fn sign(self, signing_key: &SigningKey) -> Result<SignedTransaction, bcs::Error> {
+        let message = self.signing_message()?;
+        let signature = signing_key.sign(&message);
+        Ok(SignedTransaction {
+            raw_txn: self,
+            authenticator: TransactionAuthenticator::Ed25519 {
+                public_key: signing_key.verifying_key().to_bytes().to_vec(),
+                signature: signature.to_bytes().to_vec(),
+            },
+        })
+    }
+}
+
+/// Helpers that BCS-encode a single Move argument for `EntryFunction.args`.
+pub mod args {
+    pub fn address(addr: [u8; 32]) -> Vec<u8> {
+        bcs::to_bytes(&super::AccountAddress(addr)).expect("bcs address")
+    }
+    pub fn u8(v: u8) -> Vec<u8> {
+        bcs::to_bytes(&v).expect("bcs u8")
+    }
+    pub fn u64(v: u64) -> Vec<u8> {
+        bcs::to_bytes(&v).expect("bcs u64")
+    }
+    pub fn u128(v: u128) -> Vec<u8> {
+        bcs::to_bytes(&v).expect("bcs u128")
+    }
+    pub fn string(v: &str) -> Vec<u8> {
+        bcs::to_bytes(&v.to_string()).expect("bcs string")
+    }
+    pub fn bytes(v: &[u8]) -> Vec<u8> {
+        bcs::to_bytes(&v.to_vec()).expect("bcs vector<u8>")
+    }
+    pub fn option_string(v: Option<&str>) -> Vec<u8> {
+        bcs::to_bytes(&v).expect("bcs option<string>")
+    }
+    pub fn option_bytes(v: Option<&[u8]>) -> Vec<u8> {
+        bcs::to_bytes(&v).expect("bcs option<vector<u8>>")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry(args: Vec<Vec<u8>>) -> EntryFunction {
+        EntryFunction {
+            module: ModuleId {
+                address: AccountAddress([0xCA; 32]),
+                name: "omni_bridge".to_string(),
+            },
+            function: "log_metadata".to_string(),
+            ty_args: Vec::new(),
+            args,
+        }
+    }
+
+    #[test]
+    fn bcs_primitive_args_are_little_endian_and_length_prefixed() {
+        assert_eq!(args::u64(1), vec![1, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(
+            args::u128(1),
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(args::u8(7), vec![7]);
+        // String / vector<u8>: ULEB128 length prefix + bytes.
+        assert_eq!(args::string("hi"), vec![2, b'h', b'i']);
+        assert_eq!(args::bytes(&[0xde, 0xad]), vec![2, 0xde, 0xad]);
+        // Option: 0x00 = None, 0x01 + value = Some.
+        assert_eq!(args::option_string(None), vec![0]);
+        assert_eq!(args::option_string(Some("a")), vec![1, 1, b'a']);
+        assert_eq!(args::option_bytes(None), vec![0]);
+    }
+
+    #[test]
+    fn address_arg_is_32_raw_bytes() {
+        let bytes = args::address([0xAB; 32]);
+        assert_eq!(bytes, vec![0xAB; 32]); // no length prefix
+    }
+
+    #[test]
+    fn entry_function_payload_uses_variant_index_2() {
+        let payload =
+            TransactionPayload::EntryFunction(sample_entry(vec![args::address([0x01; 32])]));
+        let bytes = bcs::to_bytes(&payload).unwrap();
+        // First byte is the ULEB128 enum variant index for EntryFunction.
+        assert_eq!(bytes[0], 2);
+    }
+
+    #[test]
+    fn signing_message_is_salt_prefixed() {
+        let raw = RawTransaction {
+            sender: AccountAddress([0x11; 32]),
+            sequence_number: 0,
+            payload: TransactionPayload::EntryFunction(sample_entry(Vec::new())),
+            max_gas_amount: 100_000,
+            gas_unit_price: 100,
+            expiration_timestamp_secs: 1_700_000_000,
+            chain_id: 2,
+        };
+        let message = raw.signing_message().unwrap();
+        let salt = raw_transaction_signing_salt();
+        assert_eq!(&message[..32], &salt);
+        assert_eq!(&message[32..], &bcs::to_bytes(&raw).unwrap()[..]);
+    }
+
+    #[test]
+    fn signed_transaction_roundtrips_through_bcs() {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let raw = RawTransaction {
+            sender: AccountAddress([0x22; 32]),
+            sequence_number: 3,
+            payload: TransactionPayload::EntryFunction(sample_entry(vec![args::u64(9)])),
+            max_gas_amount: 100_000,
+            gas_unit_price: 100,
+            expiration_timestamp_secs: 1_700_000_000,
+            chain_id: 1,
+        };
+        let signed = raw.sign(&signing_key).unwrap();
+        // Authenticator is Ed25519 (variant 0): pubkey(32) + sig(64), each
+        // length-prefixed. Serialization must not panic and must be stable.
+        let bytes = bcs::to_bytes(&signed).unwrap();
+        assert!(!bytes.is_empty());
+        let TransactionAuthenticator::Ed25519 {
+            public_key,
+            signature,
+        } = &signed.authenticator;
+        assert_eq!(public_key.len(), 32);
+        assert_eq!(signature.len(), 64);
+    }
+
+    /// Validates our hand-rolled `RawTransaction` BCS + signing-message salt
+    /// against a live Aptos fullnode's `encode_submission` (which BCS-encodes
+    /// the transaction server-side using aptos-core). Uses the always-present
+    /// `0x1::aptos_account::transfer` entry function — the encoding path is the
+    /// same one the bridge entry functions use. Ignored by default (network).
+    #[tokio::test]
+    #[ignore = "requires network access to the Aptos testnet fullnode"]
+    async fn signing_message_matches_node_encode_submission() {
+        const NODE: &str = "https://fullnode.testnet.aptoslabs.com/v1";
+
+        let mut sender = [0u8; 32];
+        sender[31] = 0x1;
+        let mut dest = [0u8; 32];
+        dest[31] = 0x2;
+
+        let raw = RawTransaction {
+            sender: AccountAddress(sender),
+            sequence_number: 0,
+            payload: TransactionPayload::EntryFunction(EntryFunction {
+                module: ModuleId {
+                    address: AccountAddress(sender), // 0x1
+                    name: "aptos_account".to_string(),
+                },
+                function: "transfer".to_string(),
+                ty_args: Vec::new(),
+                args: vec![args::address(dest), args::u64(1000)],
+            }),
+            max_gas_amount: 100_000,
+            gas_unit_price: 100,
+            expiration_timestamp_secs: 1_700_000_000,
+            chain_id: 2, // testnet
+        };
+        let ours = format!("0x{}", hex::encode(raw.signing_message().unwrap()));
+
+        let body = serde_json::json!({
+            "sender": "0x1",
+            "sequence_number": "0",
+            "max_gas_amount": "100000",
+            "gas_unit_price": "100",
+            "expiration_timestamp_secs": "1700000000",
+            "payload": {
+                "type": "entry_function_payload",
+                "function": "0x1::aptos_account::transfer",
+                "type_arguments": [],
+                "arguments": ["0x2", "1000"],
+            },
+        });
+        let theirs: String = reqwest::Client::new()
+            .post(format!("{NODE}/transactions/encode_submission"))
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+        assert_eq!(ours, theirs, "BCS signing message diverged from aptos-core");
+    }
+}

--- a/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/evm-bridge-client/src/evm_bridge_client.rs
@@ -433,7 +433,8 @@ impl EvmBridgeClient {
             | ChainKind::Fogo
             | ChainKind::Btc
             | ChainKind::Zcash
-            | ChainKind::Strk => Err(EvmBridgeClientError::InvalidArgument(format!(
+            | ChainKind::Strk
+            | ChainKind::Aptos => Err(EvmBridgeClientError::InvalidArgument(format!(
                 "Expected evm chain but got {chain_kind:?}"
             ))),
         }
@@ -616,7 +617,8 @@ impl EvmBridgeClient {
             | OmniAddress::Fogo(_)
             | OmniAddress::Btc(_)
             | OmniAddress::Zcash(_)
-            | OmniAddress::Strk(_) => Err(EvmBridgeClientError::InvalidArgument(format!(
+            | OmniAddress::Strk(_)
+            | OmniAddress::Aptos(_) => Err(EvmBridgeClientError::InvalidArgument(format!(
                 "Unsupported address type in SignTransferEvent: {address:?}",
             ))),
         }

--- a/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
+++ b/bridge-sdk/connectors/bridge-connector-common/Cargo.toml
@@ -17,3 +17,4 @@ solana-bridge-client = { path = "../../bridge-clients/solana-bridge-client" }
 utxo-bridge-client = { path = "../../bridge-clients/utxo-bridge-client" }
 evm-bridge-client = { path = "../../bridge-clients/evm-bridge-client" }
 starknet-bridge-client = { path = "../../bridge-clients/starknet-bridge-client" }
+aptos-bridge-client = { path = "../../bridge-clients/aptos-bridge-client" }

--- a/bridge-sdk/connectors/bridge-connector-common/src/result.rs
+++ b/bridge-sdk/connectors/bridge-connector-common/src/result.rs
@@ -2,6 +2,7 @@ use alloy::{
     providers::PendingTransactionError,
     transports::{RpcError, TransportErrorKind},
 };
+use aptos_bridge_client::error::AptosBridgeClientError;
 use eth_proof::{EthClientError, EthProofError};
 use evm_bridge_client::error::EvmBridgeClientError;
 use near_rpc_client::NearRpcError;
@@ -65,6 +66,10 @@ pub enum BridgeSdkError {
     StarknetRpcError(String),
     #[error("Error working with Starknet: {0}")]
     StarknetOtherError(String),
+    #[error("Error communicating with Aptos RPC: {0}")]
+    AptosRpcError(String),
+    #[error("Error working with Aptos: {0}")]
+    AptosOtherError(String),
     #[error("Transaction has not reached the required MPC finality")]
     MpcFinalityNotReached,
 }
@@ -129,6 +134,19 @@ impl From<StarknetBridgeClientError> for BridgeSdkError {
             StarknetBridgeClientError::InvalidArgument(e) => Self::InvalidArgument(e),
             StarknetBridgeClientError::TransactionError(e) => Self::StarknetOtherError(e),
             StarknetBridgeClientError::MpcFinalityNotReached => Self::MpcFinalityNotReached,
+        }
+    }
+}
+
+impl From<AptosBridgeClientError> for BridgeSdkError {
+    fn from(error: AptosBridgeClientError) -> Self {
+        match error {
+            AptosBridgeClientError::RestError(e) => Self::AptosRpcError(e),
+            AptosBridgeClientError::TransactionError(e) => Self::AptosOtherError(e),
+            AptosBridgeClientError::BlockchainDataError(e) => Self::AptosOtherError(e),
+            AptosBridgeClientError::ConfigError(e) => Self::ConfigError(e),
+            AptosBridgeClientError::InvalidArgument(e) => Self::InvalidArgument(e),
+            AptosBridgeClientError::MpcFinalityNotReached => Self::MpcFinalityNotReached,
         }
     }
 }

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -47,6 +47,7 @@ solana-bridge-client = { path = "../../bridge-clients/solana-bridge-client" }
 wormhole-bridge-client = { path = "../../bridge-clients/wormhole-bridge-client" }
 utxo-bridge-client = { path = "../../bridge-clients/utxo-bridge-client" }
 starknet-bridge-client = { path = "../../bridge-clients/starknet-bridge-client" }
+aptos-bridge-client = { path = "../../bridge-clients/aptos-bridge-client" }
 starknet.workspace = true
 near-mpc-contract-interface.workspace = true
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -6,6 +6,7 @@ use bridge_connector_common::result::{BridgeSdkError, Result};
 use derive_builder::Builder;
 use light_client::LightClient;
 use near_mpc_contract_interface::types::{
+    AptosAddress, AptosEvent, AptosExtractedValue, AptosExtractor, AptosRpcRequest, AptosTxId,
     EvmExtractedValue, EvmExtractor, EvmLog, EvmRpcRequest, EvmTxId, ExtractedValue,
     ForeignChainRpcRequest, ForeignTxSignPayload, ForeignTxSignPayloadV1, Hash160, Hash256,
     StarknetExtractedValue, StarknetExtractor, StarknetFelt, StarknetLog, StarknetRpcRequest,
@@ -28,6 +29,7 @@ use omni_types::{
     TransferMessage, UnifiedTransferId, UtxoId, H160,
 };
 
+use aptos_bridge_client::{AptosBridgeClient, AptosInitTransferEvent};
 use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
 use near_bridge_client::btc::{
     BtcConfirmationContext, BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
@@ -81,6 +83,7 @@ pub struct OmniConnector {
     btc_bridge_client: Option<UTXOBridgeClient<Bitcoin>>,
     zcash_bridge_client: Option<UTXOBridgeClient<Zcash>>,
     starknet_bridge_client: Option<StarknetBridgeClient>,
+    aptos_bridge_client: Option<AptosBridgeClient>,
     eth_light_client: Option<LightClient>,
     btc_light_client: Option<LightClient>,
     zcash_light_client: Option<LightClient>,
@@ -160,6 +163,13 @@ pub enum DeployTokenArgs {
         event: OmniBridgeEvent,
     },
     StarknetDeployTokenWithTxHash {
+        near_tx_hash: CryptoHash,
+        sender_id: Option<AccountId>,
+    },
+    AptosDeployToken {
+        event: OmniBridgeEvent,
+    },
+    AptosDeployTokenWithTxHash {
         near_tx_hash: CryptoHash,
         sender_id: Option<AccountId>,
     },
@@ -247,6 +257,14 @@ pub enum InitTransferArgs {
         native_fee: u128,
         message: String,
     },
+    AptosInitTransfer {
+        token: String,
+        amount: u128,
+        recipient: String,
+        fee: u128,
+        native_fee: u128,
+        message: String,
+    },
 }
 
 pub enum FinTransferArgs {
@@ -312,6 +330,13 @@ pub enum FinTransferArgs {
         event: OmniBridgeEvent,
     },
     StarknetFinTransferWithTxHash {
+        near_tx_hash: CryptoHash,
+        sender_id: Option<AccountId>,
+    },
+    AptosFinTransfer {
+        event: OmniBridgeEvent,
+    },
+    AptosFinTransferWithTxHash {
         near_tx_hash: CryptoHash,
         sender_id: Option<AccountId>,
     },
@@ -1839,6 +1864,58 @@ impl OmniConnector {
         })
     }
 
+    pub async fn build_aptos_mpc_sign_payload(
+        &self,
+        tx_hash: String,
+        proof_kind: ProofKind,
+    ) -> Result<Vec<u8>> {
+        let aptos_client = self.aptos_bridge_client()?;
+        let finality = aptos_client.check_mpc_finality(&tx_hash).await?;
+
+        let log = match proof_kind {
+            ProofKind::InitTransfer => aptos_client.get_init_transfer_log(&tx_hash).await?,
+            ProofKind::DeployToken => aptos_client.get_deploy_token_log(&tx_hash).await?,
+            ProofKind::FinTransfer => aptos_client.get_fin_transfer_log(&tx_hash).await?,
+            other => {
+                return Err(BridgeSdkError::InvalidArgument(format!(
+                    "Unsupported proof kind for Aptos MPC payload: {other:?}"
+                )));
+            }
+        };
+
+        let tx_id = {
+            let hex_str = tx_hash.strip_prefix("0x").unwrap_or(&tx_hash);
+            let bytes = hex::decode(hex_str).map_err(|e| {
+                BridgeSdkError::InvalidArgument(format!("Invalid Aptos tx hash {tx_hash}: {e}"))
+            })?;
+            <[u8; 32]>::try_from(bytes).map_err(|_| {
+                BridgeSdkError::InvalidArgument("Aptos tx hash must be 32 bytes".to_string())
+            })?
+        };
+
+        let sign_payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+            request: ForeignChainRpcRequest::Aptos(AptosRpcRequest {
+                tx_id: AptosTxId(tx_id),
+                finality,
+                extractors: vec![AptosExtractor::Event {
+                    event_index: log.event_index,
+                }],
+            }),
+            values: vec![ExtractedValue::AptosExtractedValue(
+                AptosExtractedValue::Event(AptosEvent {
+                    account_address: AptosAddress(log.account_address),
+                    sequence_number: log.sequence_number,
+                    type_tag: log.type_tag,
+                    data: log.data,
+                }),
+            )],
+        });
+
+        borsh::to_vec(&sign_payload).map_err(|_| {
+            BridgeSdkError::EthProofError("Failed to serialize MPC sign payload".to_string())
+        })
+    }
+
     pub async fn near_claim_fee(
         &self,
         claim_fee_args: omni_types::locker_args::ClaimFeeArgs,
@@ -2603,6 +2680,10 @@ impl OmniConnector {
                     .await
                     .map(|hash| format!("{hash:#066x}"))
             }
+            OmniAddress::Aptos(aptos_address) => {
+                self.aptos_log_metadata(format!("0x{}", hex::encode(aptos_address.0)))
+                    .await
+            }
             OmniAddress::Btc(_) | OmniAddress::Zcash(_) => Err(BridgeSdkError::InvalidArgument(
                 "Log metadata is not supported for this chain".to_string(),
             )),
@@ -2672,6 +2753,16 @@ impl OmniConnector {
                 .starknet_deploy_token_with_tx_hash(near_tx_hash, sender_id)
                 .await
                 .map(|hash| format!("{hash:#066x}")),
+            DeployTokenArgs::AptosDeployToken { event } => {
+                self.aptos_deploy_token_with_event(event).await
+            }
+            DeployTokenArgs::AptosDeployTokenWithTxHash {
+                near_tx_hash,
+                sender_id,
+            } => {
+                self.aptos_deploy_token_with_tx_hash(near_tx_hash, sender_id)
+                    .await
+            }
         }
     }
 
@@ -2741,6 +2832,10 @@ impl OmniConnector {
                                 ))
                             })?;
                         self.build_strk_mpc_sign_payload(felt, ProofKind::DeployToken)
+                            .await?
+                    }
+                    ChainKind::Aptos => {
+                        self.build_aptos_mpc_sign_payload(tx_hash, ProofKind::DeployToken)
                             .await?
                     }
                     other => {
@@ -2842,6 +2937,17 @@ impl OmniConnector {
                 .starknet_init_transfer(token, amount, fee, native_fee, recipient, message)
                 .await
                 .map(|tx_hash| format!("{tx_hash:#066x}")),
+            InitTransferArgs::AptosInitTransfer {
+                token,
+                amount,
+                recipient,
+                fee,
+                native_fee,
+                message,
+            } => {
+                self.aptos_init_transfer(token, amount, fee, native_fee, recipient, message)
+                    .await
+            }
         }
     }
 
@@ -2904,6 +3010,10 @@ impl OmniConnector {
                                 ))
                             })?;
                         self.build_strk_mpc_sign_payload(felt, ProofKind::InitTransfer)
+                            .await?
+                    }
+                    ChainKind::Aptos => {
+                        self.build_aptos_mpc_sign_payload(tx_hash, ProofKind::InitTransfer)
                             .await?
                     }
                     other => {
@@ -2989,6 +3099,16 @@ impl OmniConnector {
                 .starknet_fin_transfer_with_tx_hash(near_tx_hash, sender_id)
                 .await
                 .map(|hash| format!("{hash:#066x}")),
+            FinTransferArgs::AptosFinTransfer { event } => {
+                self.aptos_fin_transfer_with_event(event).await
+            }
+            FinTransferArgs::AptosFinTransferWithTxHash {
+                near_tx_hash,
+                sender_id,
+            } => {
+                self.aptos_fin_transfer_with_tx_hash(near_tx_hash, sender_id)
+                    .await
+            }
         }
     }
 
@@ -3031,6 +3151,10 @@ impl OmniConnector {
                                 ))
                             })?;
                         self.build_strk_mpc_sign_payload(felt, ProofKind::FinTransfer)
+                            .await?
+                    }
+                    ChainKind::Aptos => {
+                        self.build_aptos_mpc_sign_payload(tx_hash, ProofKind::FinTransfer)
                             .await?
                     }
                     other => {
@@ -3080,6 +3204,7 @@ impl OmniConnector {
             ChainKind::Sol => self.svm_is_transfer_finalised(ChainKind::Sol, nonce).await,
             ChainKind::Fogo => self.svm_is_transfer_finalised(ChainKind::Fogo, nonce).await,
             ChainKind::Strk => self.starknet_is_transfer_finalised(nonce).await,
+            ChainKind::Aptos => self.aptos_is_transfer_finalised(nonce).await,
             ChainKind::Zcash | ChainKind::Btc => Err(BridgeSdkError::ConfigError(
                 "is_transfer_finalised is not supported for UTXO chains".to_string(),
             )),
@@ -3221,7 +3346,8 @@ impl OmniConnector {
             | ChainKind::Fogo
             | ChainKind::Btc
             | ChainKind::Zcash
-            | ChainKind::Strk => {
+            | ChainKind::Strk
+            | ChainKind::Aptos => {
                 return Err(BridgeSdkError::ConfigError(format!(
                     "EVM bridge client is not available for {chain_kind:?}"
                 )));
@@ -3368,6 +3494,93 @@ impl OmniConnector {
         Ok(client.get_transfer_event(tx_hash).await?)
     }
 
+    pub fn aptos_bridge_client(&self) -> Result<&AptosBridgeClient> {
+        self.aptos_bridge_client
+            .as_ref()
+            .ok_or(BridgeSdkError::ConfigError(
+                "Aptos bridge client is not configured".to_string(),
+            ))
+    }
+
+    pub async fn aptos_log_metadata(&self, token: String) -> Result<String> {
+        let token = aptos_bridge_client::parse_account_address(&token)
+            .map_err(BridgeSdkError::InvalidArgument)?;
+        Ok(self.aptos_bridge_client()?.log_metadata(token).await?)
+    }
+
+    pub async fn aptos_deploy_token_with_event(&self, event: OmniBridgeEvent) -> Result<String> {
+        Ok(self.aptos_bridge_client()?.deploy_token(event).await?)
+    }
+
+    pub async fn aptos_deploy_token_with_tx_hash(
+        &self,
+        near_tx_hash: CryptoHash,
+        sender_id: Option<AccountId>,
+    ) -> Result<String> {
+        let near_bridge_client = self.near_bridge_client()?;
+        let transfer_log = near_bridge_client
+            .extract_transfer_log(near_tx_hash, sender_id, "LogMetadataEvent")
+            .await?;
+        self.aptos_deploy_token_with_event(serde_json::from_str(&transfer_log)?)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn aptos_init_transfer(
+        &self,
+        token: String,
+        amount: u128,
+        fee: u128,
+        native_fee: u128,
+        recipient: String,
+        message: String,
+    ) -> Result<String> {
+        let token = aptos_bridge_client::parse_account_address(&token)
+            .map_err(BridgeSdkError::InvalidArgument)?;
+        Ok(self
+            .aptos_bridge_client()?
+            .init_transfer(
+                token,
+                amount,
+                fee,
+                native_fee,
+                recipient,
+                message.into_bytes(),
+            )
+            .await?)
+    }
+
+    pub async fn aptos_fin_transfer_with_event(&self, event: OmniBridgeEvent) -> Result<String> {
+        Ok(self.aptos_bridge_client()?.fin_transfer(event).await?)
+    }
+
+    pub async fn aptos_fin_transfer_with_tx_hash(
+        &self,
+        near_tx_hash: CryptoHash,
+        sender_id: Option<AccountId>,
+    ) -> Result<String> {
+        let near_bridge_client = self.near_bridge_client()?;
+        let transfer_log = near_bridge_client
+            .extract_transfer_log(near_tx_hash, sender_id, "SignTransferEvent")
+            .await?;
+        self.aptos_fin_transfer_with_event(serde_json::from_str(&transfer_log)?)
+            .await
+    }
+
+    pub async fn aptos_is_transfer_finalised(&self, nonce: u64) -> Result<bool> {
+        Ok(self
+            .aptos_bridge_client()?
+            .is_transfer_finalised(nonce)
+            .await?)
+    }
+
+    pub async fn aptos_get_transfer_event(&self, tx_hash: &str) -> Result<AptosInitTransferEvent> {
+        Ok(self
+            .aptos_bridge_client()?
+            .get_transfer_event(tx_hash)
+            .await?)
+    }
+
     pub fn wormhole_bridge_client(&self) -> Result<&WormholeBridgeClient> {
         self.wormhole_bridge_client
             .as_ref()
@@ -3406,7 +3619,8 @@ impl OmniConnector {
             | ChainKind::Abs
             | ChainKind::Sol
             | ChainKind::Fogo
-            | ChainKind::Strk => Err(BridgeSdkError::ConfigError(
+            | ChainKind::Strk
+            | ChainKind::Aptos => Err(BridgeSdkError::ConfigError(
                 "UTXO bridge client is not configured".to_string(),
             )),
         }
@@ -3476,6 +3690,10 @@ impl OmniConnector {
                     ))
                 })?;
                 self.get_storage_deposit_actions_for_starknet_tx(felt).await
+            }
+            ChainKind::Aptos => {
+                self.get_storage_deposit_actions_for_aptos_tx(&tx_hash)
+                    .await
             }
             ChainKind::Near | ChainKind::Btc | ChainKind::Zcash => {
                 Err(BridgeSdkError::ConfigError(
@@ -3629,6 +3847,60 @@ impl OmniConnector {
 
         self.get_storage_deposit_actions(
             ChainKind::Strk,
+            &recipient,
+            &fee_recipient,
+            &token_address,
+            transfer_event.fee,
+            transfer_event.native_fee,
+        )
+        .await
+    }
+
+    pub async fn get_storage_deposit_actions_for_aptos_tx(
+        &self,
+        tx_hash: &str,
+    ) -> Result<Vec<StorageDepositAction>> {
+        let transfer_event = self.aptos_get_transfer_event(tx_hash).await?;
+
+        let token_address =
+            OmniAddress::new_from_slice(ChainKind::Aptos, &transfer_event.token_address).map_err(
+                |_| {
+                    BridgeSdkError::InvalidArgument(format!(
+                        "Failed to parse token address: 0x{}",
+                        hex::encode(transfer_event.token_address)
+                    ))
+                },
+            )?;
+
+        let mut recipient = OmniAddress::from_str(&transfer_event.recipient).map_err(|_| {
+            BridgeSdkError::InvalidArgument(format!(
+                "Failed to parse recipient: {}",
+                transfer_event.recipient
+            ))
+        })?;
+
+        let mut fee_recipient = self
+            .near_bridge_client()
+            .and_then(NearBridgeClient::account_id)
+            .map_err(|_| {
+                BridgeSdkError::ConfigError("NEAR bridge client is not configured".to_string())
+            })?;
+
+        self.apply_fast_transfer_override(
+            ChainKind::Aptos,
+            &token_address,
+            transfer_event.origin_nonce,
+            transfer_event.amount,
+            transfer_event.fee,
+            transfer_event.native_fee,
+            &transfer_event.message,
+            &mut recipient,
+            &mut fee_recipient,
+        )
+        .await?;
+
+        self.get_storage_deposit_actions(
+            ChainKind::Aptos,
             &recipient,
             &fee_recipient,
             &token_address,


### PR DESCRIPTION
Add Aptos chain support to the SDK & CLI

Adds end-to-end Aptos support to the Omni Bridge SDK, mirroring the existing
Starknet integration. Aptos uses NEAR-MPC secp256k1 signatures with
byte-identical Borsh payloads, so it slots into the same proof flow.

<img width="704" height="133" alt="image" src="https://github.com/user-attachments/assets/dbff4fca-6102-4531-a3d1-2035891b4ca0" />
https://explorer.aptoslabs.com/txn/0xb228f96d5ee6d4e2311aacf35071bcceda1d558a7164e19a2b15141c7813c9a0/events?network=mainnet

What's included
- New `aptos-bridge-client` crate — submits `log_metadata`, `deploy_token`,
  `init_transfer`, and `fin_transfer` to the Aptos `omni_bridge` Move package,
  plus the `is_transfer_finalised` view and event-log readers for MPC proofs.
  Lightweight stack (REST + bcs + ed25519-dalek), no aptos-core dependency.
- `omni-connector` wiring — `aptos_bridge_client` field, `aptos_*` helpers,
  `build_aptos_mpc_sign_payload` (Aptos→NEAR), new arg-enum variants, and Aptos
  arms across every dispatch/exhaustive match.
- `bridge-cli` — `AptosInitTransfer`/`AptosFinTransfer` commands, `aptos_*`
  config (CLI args / env / defaults), and Aptos routing in
  `DeployToken`/`NearFinTransfer`/`BindToken`.
- Deps — bump `omni-types` to the Aptos rev and pin `near-mpc-contract-interface`
  to `near/mpc` (Aptos MPC types); add `bcs` + `ed25519-dalek`.
- Claude PR-review workflow — `.github/workflows/claude-pr-review.yml` + prompt +
  comment-fetch script (uses the org `ANTHROPIC_API` secret).

Notes
- Bridge addresses in `defaults.rs` are zero placeholders — set them once the
  Aptos contract is deployed.
- NEAR → Aptos works today. Aptos → NEAR finalization builds the correct payload
  but is only honored once the MPC network ships the Aptos foreign-tx extractor
  (near/mpc #3508) and an Aptos prover is registered on NEAR.

Testing
`cargo build`, `fmt --check`, and `clippy` are clean; all tests pass (incl. 13
new in `aptos-bridge-client`). The Aptos transaction BCS + signing message is
validated byte-for-byte against a live Aptos node's `encode_submission`.
