### PR TITLE
feat(cli): --dry-run to emit unsigned NEAR transactions for offline signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.61"
+version = "0.3.62"
 dependencies = [
  "alloy",
  "clap",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy",
  "bip0039",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5280,6 +5280,7 @@ dependencies = [
 name = "near-rpc-client"
 version = "0.2.0"
 dependencies = [
+ "base64 0.22.1",
  "borsh 1.6.1",
  "hex",
  "lazy_static",

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.61"
+version = "0.3.62"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/README.md
+++ b/bridge-cli/README.md
@@ -77,6 +77,42 @@ You can create a configuration file with your preferred settings. The CLI will l
 
 You can manually modify `bridge-cli/src/defaults.rs` file
 
+### Offline / hardware-wallet signing (NEAR)
+
+Any command that submits a NEAR transaction supports `--dry-run`. Instead of
+signing and broadcasting, the CLI builds the transaction (fetching the current
+nonce and a recent block hash) and prints it as a base64-encoded borsh payload,
+ready to be signed externally — e.g. on a hardware wallet — and submitted by you.
+
+`--dry-run` is only valid for NEAR commands; using it on a command that submits
+to another chain (EVM/SVM/Starknet, `btc-fin-transfer`, or `deploy-token` to a
+non-Near chain) exits with an error rather than broadcasting.
+
+In this mode **no private key is needed**; supply the signer account and the
+public key that will sign (the access key must exist on the account):
+
+```bash
+bridge-cli mainnet log-metadata \
+    --token near:wrap.near \
+    --near-signer omni-relayer.near \
+    --near-public-key ed25519:Hb... \
+    --dry-run
+```
+
+This prints a human-readable summary plus:
+
+```
+unsigned transaction (base64-encoded borsh):
+CQAAA...AAAA
+```
+
+Sign and submit the printed payload with your preferred tool, for example
+`near transaction sign-transaction <base64> ...` in
+[near-cli-rs](https://github.com/near/near-cli-rs). The block hash is only valid
+for ~24h, so sign and submit promptly.
+
+Equivalent env vars: `NEAR_PUBLIC_KEY`, `DRY_RUN=true`.
+
 ## Quick Start
 
 ### Example 1: Deploy an ERC20 Token to NEAR
@@ -233,8 +269,10 @@ bridge-cli mainnet btc-request-refund \
 #                         relying on the indexer lookup. These must match the
 #                         values used at deposit time; the contract recomputes
 #                         the deposit address from them and rejects mismatches.
-#   --dry-run           — print the `request_refund` call args as JSON without
-#                         submitting the NEAR transaction.
+#   --dry-run           — print the unsigned `request_refund` NEAR transaction
+#                         (base64 borsh) for offline/hardware-wallet signing
+#                         instead of submitting it. Requires --near-public-key.
+#                         See "Offline / hardware-wallet signing (NEAR)" above.
 #
 # Example with manual args (safe_deposit.msg path; `receiver_id` inside --msg
 # is the intents account the deposit was routed to):

--- a/bridge-cli/src/main.rs
+++ b/bridge-cli/src/main.rs
@@ -17,6 +17,17 @@ struct CliConfig {
     near_signer: Option<String>,
     #[arg(long)]
     near_private_key: Option<String>,
+    #[arg(
+        long,
+        help = "NEAR signer public key; required with --dry-run for offline/hardware-wallet signing"
+    )]
+    near_public_key: Option<String>,
+    #[arg(
+        long,
+        help = "Build and print the unsigned NEAR transaction (base64 borsh) instead of signing and broadcasting it. Only valid for NEAR commands; errors on other chains"
+    )]
+    #[serde(default)]
+    dry_run: bool,
     #[arg(long)]
     near_token_locker_id: Option<String>,
     #[arg(long)]
@@ -165,6 +176,8 @@ impl CliConfig {
             near_rpc: self.near_rpc.or(other.near_rpc),
             near_signer: self.near_signer.or(other.near_signer),
             near_private_key: self.near_private_key.or(other.near_private_key),
+            near_public_key: self.near_public_key.or(other.near_public_key),
+            dry_run: self.dry_run || other.dry_run,
             near_token_locker_id: self.near_token_locker_id.or(other.near_token_locker_id),
             near_mpc_omni_prover_id: self
                 .near_mpc_omni_prover_id
@@ -283,6 +296,8 @@ fn env_config() -> CliConfig {
         near_rpc: env::var("NEAR_RPC").ok(),
         near_signer: env::var("NEAR_SIGNER").ok(),
         near_private_key: env::var("NEAR_PRIVATE_KEY").ok(),
+        near_public_key: env::var("NEAR_PUBLIC_KEY").ok(),
+        dry_run: env::var("DRY_RUN").is_ok_and(|s| s == "true"),
         near_token_locker_id: env::var("TOKEN_LOCKER_ID").ok(),
         near_mpc_omni_prover_id: env::var("MPC_OMNI_PROVER_ID").ok(),
         eth_light_client_id: env::var("ETH_LIGHT_CLIENT_ID").ok(),
@@ -383,6 +398,8 @@ fn default_config(network: Network) -> CliConfig {
             near_rpc: Some(defaults::NEAR_RPC_MAINNET.to_owned()),
             near_signer: None,
             near_private_key: None,
+            near_public_key: None,
+            dry_run: false,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_MAINNET.to_owned()),
             near_mpc_omni_prover_id: Some(defaults::NEAR_MPC_OMNI_PROVER_ID_MAINNET.to_owned()),
             eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_MAINNET.to_owned()),
@@ -488,6 +505,8 @@ fn default_config(network: Network) -> CliConfig {
             near_rpc: Some(defaults::NEAR_RPC_TESTNET.to_owned()),
             near_signer: None,
             near_private_key: None,
+            near_public_key: None,
+            dry_run: false,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_TESTNET.to_owned()),
             near_mpc_omni_prover_id: Some(defaults::NEAR_MPC_OMNI_PROVER_ID_TESTNET.to_owned()),
             eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_TESTNET.to_owned()),
@@ -594,6 +613,8 @@ fn default_config(network: Network) -> CliConfig {
             near_rpc: Some(defaults::NEAR_RPC_DEVNET.to_owned()),
             near_signer: None,
             near_private_key: None,
+            near_public_key: None,
+            dry_run: false,
             near_token_locker_id: Some(defaults::NEAR_TOKEN_LOCKER_ID_DEVNET.to_owned()),
             near_mpc_omni_prover_id: Some(defaults::NEAR_MPC_OMNI_PROVER_ID_DEVNET.to_owned()),
             eth_light_client_id: Some(defaults::ETH_LIGHT_CLIENT_ID_DEVNET.to_owned()),

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -700,11 +700,6 @@ pub enum OmniConnectorSubCommand {
             help = "Optional msg set as SafeDepositMsg.msg (only valid with direct recipient, i.e. without chain prefix)"
         )]
         msg: Option<String>,
-        #[clap(
-            long,
-            help = "Print the call args as JSON without submitting the transaction"
-        )]
-        dry_run: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -793,11 +788,6 @@ pub enum OmniConnectorSubCommand {
         no_deposit_refund_address: bool,
         #[clap(long, help = "Optional custom gas fee in satoshi (DAO/Operator only)")]
         gas_fee: Option<u128>,
-        #[clap(
-            long,
-            help = "Print the call args as JSON without submitting the transaction"
-        )]
-        dry_run: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -898,8 +888,49 @@ pub(crate) enum InternalSubCommand {
     },
 }
 
+/// `--dry-run` builds and prints an unsigned NEAR transaction; it is meaningless
+/// (and dangerous to silently ignore) for commands that broadcast to another
+/// chain. Reject those up front so a stray `--dry-run` never lets a non-NEAR
+/// transaction go out for real.
+fn ensure_dry_run_supported(cmd: &OmniConnectorSubCommand, network: Network) {
+    use OmniConnectorSubCommand as Cmd;
+
+    let submits_to_non_near = match cmd {
+        Cmd::EvmInitTransfer { config_cli, .. }
+        | Cmd::EvmFinTransfer { config_cli, .. }
+        | Cmd::StarknetInitTransfer { config_cli, .. }
+        | Cmd::StarknetFinTransfer { config_cli, .. }
+        | Cmd::SvmInitialize { config_cli, .. }
+        | Cmd::SvmInitTransfer { config_cli, .. }
+        | Cmd::SvmInitTransferSol { config_cli, .. }
+        | Cmd::SvmFinalizeTransfer { config_cli, .. }
+        | Cmd::SvmFinalizeTransferSol { config_cli, .. }
+        | Cmd::SvmSetAdmin { config_cli, .. }
+        | Cmd::SvmPause { config_cli, .. }
+        | Cmd::SvmUpdateMetadata { config_cli, .. }
+        | Cmd::BtcFinTransfer { config_cli, .. } => {
+            combined_config(config_cli.clone(), network).dry_run
+        }
+        // `deploy-token --chain Near` is a NEAR transaction; any other chain is not.
+        Cmd::DeployToken {
+            chain, config_cli, ..
+        } if *chain != ChainKind::Near => combined_config(config_cli.clone(), network).dry_run,
+        _ => false,
+    };
+
+    if submits_to_non_near {
+        eprintln!(
+            "error: --dry-run is only supported for NEAR transactions; this command \
+             submits to another chain and would broadcast for real"
+        );
+        std::process::exit(1);
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
+    ensure_dry_run_supported(&cmd, network);
+
     match cmd {
         OmniConnectorSubCommand::LogMetadata { token, config_cli } => {
             omni_connector(network, config_cli)
@@ -1571,7 +1602,6 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             refund_address,
             fee,
             msg,
-            dry_run,
             config_cli,
         } => {
             let connector = omni_connector(network, config_cli);
@@ -1601,37 +1631,19 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             )
             .await;
 
-            if dry_run {
-                let args = connector
-                    .build_fin_btc_transfer_args(
-                        chain.into(),
-                        btc_tx_hash,
-                        resolved_vout,
-                        deposit_args,
-                        prefetched,
-                    )
-                    .await
-                    .unwrap();
-                let method_name = if args.deposit_msg.safe_deposit.is_some() {
-                    "safe_verify_deposit"
-                } else {
-                    "verify_deposit"
-                };
-                println!("method: {method_name}");
-                println!("args: {}", serde_json::to_string_pretty(&args).unwrap());
-            } else {
-                connector
-                    .fin_transfer(FinTransferArgs::NearFinTransferBTC {
-                        chain_kind: chain.into(),
-                        btc_tx_hash,
-                        vout: resolved_vout,
-                        btc_deposit_args: deposit_args,
-                        prefetched,
-                        transaction_options: TransactionOptions::default(),
-                    })
-                    .await
-                    .unwrap();
-            }
+            // `--dry-run` (if set) is honored at the NEAR client: the verify_deposit
+            // transaction is printed as an unsigned payload instead of broadcast.
+            connector
+                .fin_transfer(FinTransferArgs::NearFinTransferBTC {
+                    chain_kind: chain.into(),
+                    btc_tx_hash,
+                    vout: resolved_vout,
+                    btc_deposit_args: deposit_args,
+                    prefetched,
+                    transaction_options: TransactionOptions::default(),
+                })
+                .await
+                .unwrap();
         }
         OmniConnectorSubCommand::BtcVerifyWithdraw {
             chain,
@@ -1693,7 +1705,6 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             msg,
             no_deposit_refund_address,
             gas_fee,
-            dry_run,
             config_cli,
         } => {
             let chain_kind: ChainKind = chain.into();
@@ -1750,34 +1761,20 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
                     )
                 });
 
-            if dry_run {
-                let args = connector
-                    .build_btc_request_refund_args(
-                        &btc_tx_hash,
-                        resolved_vout,
-                        btc_deposit_args,
-                        final_refund_address,
-                        gas_fee,
-                        prefetched,
-                    )
-                    .await
-                    .unwrap();
-                println!("method: request_refund");
-                println!("args: {}", serde_json::to_string_pretty(&args).unwrap());
-            } else {
-                connector
-                    .btc_request_refund(
-                        btc_tx_hash,
-                        resolved_vout,
-                        btc_deposit_args,
-                        final_refund_address,
-                        gas_fee,
-                        prefetched,
-                        TransactionOptions::default(),
-                    )
-                    .await
-                    .unwrap();
-            }
+            // `--dry-run` (if set) is honored at the NEAR client: the request_refund
+            // transaction is printed as an unsigned payload instead of broadcast.
+            connector
+                .btc_request_refund(
+                    btc_tx_hash,
+                    resolved_vout,
+                    btc_deposit_args,
+                    final_refund_address,
+                    gas_fee,
+                    prefetched,
+                    TransactionOptions::default(),
+                )
+                .await
+                .unwrap();
         }
         OmniConnectorSubCommand::BtcVerifyRefundFinalize {
             btc_tx_hash,
@@ -1913,6 +1910,8 @@ fn omni_connector(network: Network, cli_config: CliConfig) -> OmniConnector {
                 .near_signer
                 .map(|account| account.parse().unwrap()),
         )
+        .signer_public_key(combined_config.near_public_key)
+        .dry_run(combined_config.dry_run)
         .omni_bridge_id(
             combined_config
                 .near_token_locker_id

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/near_bridge_client.rs
@@ -100,6 +100,12 @@ pub struct NearBridgeClient {
     private_key: Option<String>,
     #[doc = r"NEAR account id of the transaction signer"]
     signer: Option<AccountId>,
+    #[doc = r"NEAR public key of the signer (used for dry-run/offline signing, e.g. a hardware wallet)"]
+    #[builder(default)]
+    signer_public_key: Option<String>,
+    #[doc = r"When set, NEAR transactions are printed as an unsigned payload instead of being signed and broadcast"]
+    #[builder(default)]
+    dry_run: bool,
     #[doc = r"`OmniBridge` account id on Near"]
     omni_bridge_id: Option<AccountId>,
     #[doc = r"`MpcOmniProver` account id on Near"]
@@ -986,21 +992,41 @@ impl NearBridgeClient {
             .cloned()
     }
 
-    pub fn signer(&self) -> Result<near_crypto::InMemorySigner> {
+    pub fn signer(&self) -> Result<near_rpc_client::TxSigner> {
+        let signer_id = self.account_id()?;
+
+        // In dry-run mode no secret key is available (it lives on the hardware
+        // wallet); build a public-key-only signer so the transaction can be
+        // assembled and printed for offline signing.
+        if self.dry_run {
+            let public_key = self
+                .signer_public_key
+                .as_ref()
+                .ok_or(BridgeSdkError::ConfigError(
+                    "Near signer public key is not set (required for dry-run)".to_string(),
+                ))?
+                .parse()
+                .map_err(|_| BridgeSdkError::ConfigError("Invalid near public key".to_string()))?;
+
+            return Ok(near_rpc_client::TxSigner::DryRun {
+                account_id: signer_id,
+                public_key,
+            });
+        }
+
         let private_key = self
             .private_key
             .as_ref()
             .ok_or(BridgeSdkError::ConfigError(
                 "Near account private key is not set".to_string(),
             ))?;
-        let signer_id = self.account_id()?;
 
         if let Signer::InMemory(signer) = near_crypto::InMemorySigner::from_secret_key(
             signer_id,
             SecretKey::from_str(private_key)
                 .map_err(|_| BridgeSdkError::ConfigError("Invalid near private key".to_string()))?,
         ) {
-            Ok(signer)
+            Ok(near_rpc_client::TxSigner::InMemory(signer))
         } else {
             Err(BridgeSdkError::ConfigError(
                 "Failed to create near signer".to_string(),

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/near-rpc-client/Cargo.toml
+++ b/bridge-sdk/near-rpc-client/Cargo.toml
@@ -15,6 +15,7 @@ near-primitives.workspace = true
 near-crypto.workspace = true
 near-token.workspace = true
 borsh.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 hex.workspace = true

--- a/bridge-sdk/near-rpc-client/src/error.rs
+++ b/bridge-sdk/near-rpc-client/src/error.rs
@@ -22,4 +22,11 @@ pub enum NearRpcError {
     NonceError,
     #[error("Could not confirm that transaction was finalized")]
     FinalizationError,
+    #[error("Could not serialize transaction")]
+    SerializationError,
+    #[error("Public key {public_key} is not an access key on account {account_id}")]
+    UnknownAccessKey {
+        account_id: String,
+        public_key: String,
+    },
 }

--- a/bridge-sdk/near-rpc-client/src/near_rpc_client.rs
+++ b/bridge-sdk/near-rpc-client/src/near_rpc_client.rs
@@ -2,6 +2,7 @@ use std::sync::LazyLock;
 
 use crate::error::NearRpcError;
 use crate::light_client_proof::LightClientExecutionProof;
+use base64::Engine;
 use near_jsonrpc_client::errors::{
     JsonRpcError, JsonRpcServerError, JsonRpcServerResponseStatusError,
 };
@@ -31,9 +32,47 @@ pub struct ViewRequest {
     pub args: serde_json::Value,
 }
 
+/// Identity used to build a NEAR transaction.
+///
+/// `InMemory` holds a secret key: transactions are signed and broadcast as usual.
+/// `DryRun` holds only a public identity (account id + public key, e.g. of a
+/// hardware wallet). Transactions built with it are printed as an unsigned
+/// payload for external signing instead of being signed and broadcast.
+#[derive(Clone)]
+pub enum TxSigner {
+    InMemory(near_crypto::InMemorySigner),
+    DryRun {
+        account_id: AccountId,
+        public_key: near_crypto::PublicKey,
+    },
+}
+
+impl TxSigner {
+    #[must_use]
+    pub fn account_id(&self) -> AccountId {
+        match self {
+            Self::InMemory(signer) => signer.account_id.clone(),
+            Self::DryRun { account_id, .. } => account_id.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn public_key(&self) -> near_crypto::PublicKey {
+        match self {
+            Self::InMemory(signer) => signer.public_key.clone(),
+            Self::DryRun { public_key, .. } => public_key.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_dry_run(&self) -> bool {
+        matches!(self, Self::DryRun { .. })
+    }
+}
+
 #[derive(Clone)]
 pub struct ChangeRequest {
-    pub signer: near_crypto::InMemorySigner,
+    pub signer: TxSigner,
     pub nonce: Option<u64>,
     pub receiver_id: AccountId,
     pub method_name: String,
@@ -148,15 +187,30 @@ pub async fn change(
 ) -> Result<CryptoHash, NearRpcError> {
     let client = DEFAULT_CONNECTOR.connect(server_addr);
 
+    let signer_account_id = change_request.signer.account_id();
+    let signer_public_key = change_request.signer.public_key();
+
     let rpc_request = methods::query::RpcQueryRequest {
         block_reference: BlockReference::latest(),
-        request: near_primitives::views::QueryRequest::ViewAccessKey {
-            account_id: change_request.signer.account_id.clone(),
-            public_key: change_request.signer.public_key.clone(),
+        request: QueryRequest::ViewAccessKey {
+            account_id: signer_account_id.clone(),
+            public_key: signer_public_key.clone(),
         },
     };
 
-    let access_key_query_response = client.call(rpc_request).await?;
+    let access_key_query_response = client.call(rpc_request).await.map_err(|err| {
+        if let Some(near_jsonrpc_client::methods::query::RpcQueryError::UnknownAccessKey {
+            ..
+        }) = err.handler_error()
+        {
+            NearRpcError::UnknownAccessKey {
+                account_id: signer_account_id.to_string(),
+                public_key: signer_public_key.to_string(),
+            }
+        } else {
+            NearRpcError::from(err)
+        }
+    })?;
 
     let nonce = if let Some(nonce) = change_request.nonce {
         nonce
@@ -170,8 +224,8 @@ pub async fn change(
     };
 
     let transaction = Transaction::V0(TransactionV0 {
-        signer_id: change_request.signer.account_id.clone(),
-        public_key: change_request.signer.public_key.clone(),
+        signer_id: signer_account_id,
+        public_key: signer_public_key,
         nonce,
         receiver_id: change_request.receiver_id,
         block_hash: access_key_query_response.block_hash,
@@ -182,11 +236,62 @@ pub async fn change(
             deposit: NearToken::from_yoctonear(change_request.deposit),
         }))],
     });
-    let request = methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
-        signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(change_request.signer)),
+
+    match change_request.signer {
+        // Dry run: print the unsigned transaction for external signing (e.g. a
+        // hardware wallet) instead of signing and broadcasting it.
+        TxSigner::DryRun { .. } => print_unsigned_transaction(&transaction),
+        TxSigner::InMemory(signer) => {
+            let request = methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
+                signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(signer)),
+            };
+
+            Ok(client.call(request).await?)
+        }
+    }
+}
+
+/// Serializes the unsigned transaction (borsh + base64) and prints it together
+/// with a human-readable summary, so it can be signed offline. Returns the hash
+/// of the unsigned transaction (which equals the signed transaction hash, since
+/// the signature is not part of the hashed payload).
+fn print_unsigned_transaction(transaction: &Transaction) -> Result<CryptoHash, NearRpcError> {
+    let tx_bytes = borsh::to_vec(transaction).map_err(|_| NearRpcError::SerializationError)?;
+    let tx_hash = CryptoHash::hash_bytes(&tx_bytes);
+    let base64_tx = base64::engine::general_purpose::STANDARD.encode(&tx_bytes);
+
+    let (method_name, args, gas, deposit) = match transaction.actions().first() {
+        Some(Action::FunctionCall(action)) => (
+            action.method_name.as_str(),
+            String::from_utf8_lossy(&action.args).into_owned(),
+            action.gas.as_gas(),
+            action.deposit.as_yoctonear(),
+        ),
+        _ => ("<unknown>", String::new(), 0u64, 0u128),
     };
 
-    Ok(client.call(request).await?)
+    println!("========================================================================");
+    println!("DRY RUN — transaction was NOT signed or broadcast");
+    println!("========================================================================");
+    println!("signer:      {}", transaction.signer_id());
+    println!("public_key:  {}", transaction.public_key());
+    println!("nonce:       {}", transaction.nonce());
+    println!("receiver:    {}", transaction.receiver_id());
+    println!("block_hash:  {}", transaction.block_hash());
+    println!("method:      {method_name}");
+    println!("gas:         {gas}");
+    println!("deposit:     {deposit} yoctoNEAR");
+    println!("args:        {args}");
+    println!("tx_hash:     {tx_hash}");
+    println!();
+    println!("unsigned transaction (base64-encoded borsh):");
+    println!("{base64_tx}");
+    println!("------------------------------------------------------------------------");
+    println!("Nothing was broadcast. Sign this payload externally (e.g. hardware");
+    println!("wallet) and submit it. Ignore any \"Sent ...\" confirmation logged below.");
+    println!("========================================================================");
+
+    Ok(tx_hash)
 }
 
 /// Returns the result of the view call and waits for the desired outcome
@@ -199,12 +304,19 @@ pub async fn change_and_wait(
     wait_until: near_primitives::views::TxExecutionStatus,
     wait_final_outcome_timeout_sec: Option<u64>,
 ) -> Result<CryptoHash, NearRpcError> {
-    let tx_hash = change(server_addr, change_request.clone()).await?;
+    let is_dry_run = change_request.signer.is_dry_run();
+    let signer_account_id = change_request.signer.account_id();
+
+    let tx_hash = change(server_addr, change_request).await?;
+
+    if is_dry_run {
+        return Ok(tx_hash);
+    }
 
     wait_for_tx(
         server_addr,
         tx_hash,
-        change_request.signer.account_id,
+        signer_account_id,
         wait_until,
         wait_final_outcome_timeout_sec.unwrap_or(DEFAULT_WAIT_FINAL_OUTCOME_TIMEOUT_SEC),
     )


### PR DESCRIPTION
## Summary

Adds a generic `--dry-run` flag to the bridge CLI for **offline / hardware-wallet signing** of NEAR transactions, intended for mainnet maintenance.

When `--dry-run` is set, NEAR commands build the transaction (fetching the current access-key nonce and a recent block hash) and **print it as a base64-encoded borsh unsigned transaction** plus a human-readable summary, instead of signing and broadcasting. The operator then signs the payload externally (e.g. a Ledger via `near-cli-rs`) and submits it.

- **No private key required.** Supply the signer account (`--near-signer`) and the public key that will sign (`--near-public-key`); the access key must already exist on the account.
- **Covers all NEAR mutating commands** — implemented once at the `near-rpc-client` choke point.
- **Safe by construction:** `--dry-run` errors on commands that submit to another chain (EVM/SVM/Starknet, `btc-fin-transfer`, `deploy-token` to a non-Near chain), so it can never silently let a non-NEAR transaction broadcast for real.

```
$ bridge-cli mainnet log-metadata --token near:wrap.near \
      --near-signer omni-relayer.near --near-public-key ed25519:Hb... --dry-run
========================================================================
DRY RUN — transaction was NOT signed or broadcast
========================================================================
signer:      omni-relayer.near
public_key:  ed25519:Hb...
nonce:       ...
receiver:    omni.bridge.near
method:      log_metadata
gas:         300000000000000
deposit:     1 yoctoNEAR
args:        {"token_id":"wrap.near"}
tx_hash:     ...
unsigned transaction (base64-encoded borsh):
CQAAA...AAAA
```

## Implementation

- **`near-rpc-client`**: new `TxSigner` enum (`InMemory` vs `DryRun { account_id, public_key }`); `ChangeRequest.signer` uses it. `change()` builds the transaction and, for `DryRun`, prints the base64 payload + summary and returns the (unsigned) tx hash without broadcasting; `change_and_wait()` skips the wait. Adds the `base64` dependency. The signing key derives `TxSigner` once, so no churn across the ~22 `ChangeRequest` build sites.
- **`near-bridge-client`**: adds `dry_run` and `signer_public_key` builder fields; `signer()` returns a `TxSigner` (public-key-only in dry-run, so no private key is needed).
- **`bridge-cli`**: `--dry-run` / `--near-public-key` flags (+ `DRY_RUN` / `NEAR_PUBLIC_KEY` env vars), wired into the `NearBridgeClient` builder; a centralized guard rejects `--dry-run` on non-NEAR commands; README section documenting the flow. The two pre-existing BTC `--dry-run` flags are folded into this generic one.
- **Clear errors**: the opaque `UnknownAccessKey` RPC error is mapped to `Public key <pk> is not an access key on account <id>`. SDK errors carry no CLI-flag vocabulary (kept the library/CLI layering clean).

## Testing

- Full workspace builds; `cargo fmt --check` clean on changed files; `cargo clippy` clean (pre-existing warnings only); affected-crate tests pass.
- **Live mainnet checks**: a real `log-metadata --dry-run` (no private key) fetched the nonce/block hash and printed the unsigned tx without broadcasting; the base64 decodes back to valid borsh with the expected fields, and the printed `tx_hash` equals `base58(sha256(borsh(tx)))` (the canonical NEAR tx hash). Verified the non-NEAR guard (`evm-init-transfer --dry-run` exits 1; `deploy-token --chain Near` passes), and the friendly `UnknownAccessKey` message on a wrong key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)