### PR TITLE
Support Zcash NU6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,11 +3131,11 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.2.2"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+version = "0.3.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
 ]
 
 [[package]]
@@ -3304,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3760,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -5703,7 +5709,7 @@ dependencies = [
  "near-sdk",
  "near-token",
  "omni-types",
- "orchard 0.12.0",
+ "orchard 0.14.0",
  "pczt",
  "rand 0.8.5",
  "ripemd 0.1.3",
@@ -5718,11 +5724,11 @@ dependencies = [
  "utxo-bridge-client",
  "utxo-utils",
  "wormhole-bridge-client",
- "zcash_address 0.10.1 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
+ "zcash_address 0.12.0",
  "zcash_keys",
- "zcash_primitives 0.26.1",
- "zcash_protocol 0.7.1",
- "zcash_transparent 0.6.1",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
@@ -5883,18 +5889,18 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.12.0"
-source = "git+https://github.com/Near-One/orchard?rev=a43977f07e6fdadff214bb081a481756a28b41fc#a43977f07e6fdadff214bb081a481756a28b41fc"
+version = "0.14.0"
+source = "git+https://github.com/Near-One/orchard?rev=dc5a778e31166658085d13580e541364d56a6547#dc5a778e31166658085d13580e541364d56a6547"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "corez",
  "ff",
  "fpe",
  "getset",
  "group",
- "halo2_gadgets 0.4.0",
+ "halo2_gadgets 0.5.0",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -6048,8 +6054,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.5.0"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+version = "0.7.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6058,20 +6064,20 @@ dependencies = [
  "getset",
  "jubjub",
  "nonempty",
- "orchard 0.12.0",
+ "orchard 0.14.0",
  "pasta_curves",
  "postcard",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives 0.26.1",
- "zcash_protocol 0.7.1",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent 0.6.1",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
@@ -7107,9 +7113,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5433ab8c1cd52dfad3b903143e371d5bdd514ab7952f71414e6d66a5da8223cd"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -7117,7 +7123,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2",
+ "corez",
  "document-features",
  "ff",
  "fpe",
@@ -11122,13 +11128,13 @@ dependencies = [
  "k256",
  "near-sdk",
  "omni-types",
- "orchard 0.12.0",
+ "orchard 0.14.0",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_with",
- "zcash_address 0.10.1 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_protocol 0.7.1",
+ "zcash_address 0.12.0",
+ "zcash_protocol 0.9.0",
 ]
 
 [[package]]
@@ -11986,7 +11992,7 @@ dependencies = [
  "bs58 0.5.1",
  "core2",
  "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0",
  "zcash_protocol 0.6.2",
 ]
 
@@ -12000,21 +12006,21 @@ dependencies = [
  "bs58 0.5.1",
  "core2",
  "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0",
  "zcash_protocol 0.7.2",
 ]
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+version = "0.12.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "bech32",
  "bs58 0.5.1",
- "core2",
- "f4jumble 0.1.1 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_encoding 0.3.0 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_protocol 0.7.1",
+ "corez",
+ "f4jumble 0.1.1 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.9.0",
 ]
 
 [[package]]
@@ -12029,10 +12035,10 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.3.0"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+version = "0.4.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
- "core2",
+ "corez",
  "hex",
  "nonempty",
 ]
@@ -12067,8 +12073,8 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0",
  "zcash_protocol 0.7.2",
  "zcash_transparent 0.6.3",
  "zip32",
@@ -12100,7 +12106,7 @@ dependencies = [
  "core2",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.2.2",
  "ff",
  "fpe",
  "getset",
@@ -12121,7 +12127,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.9.0",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0",
  "zcash_note_encryption",
  "zcash_protocol 0.6.2",
  "zcash_spec",
@@ -12131,44 +12137,32 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.1"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
+version = "0.28.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
- "bip32",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58 0.5.1",
- "core2",
+ "corez",
  "crypto-common 0.2.0-rc.1",
- "equihash 0.2.2 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
+ "equihash 0.3.0",
  "ff",
- "fpe",
- "getset",
- "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.12.0",
+ "orchard 0.14.0",
  "proptest",
- "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
- "ripemd 0.1.3",
- "sapling-crypto 0.6.0",
+ "sapling-crypto 0.7.0",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address 0.10.1 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_encoding 0.3.0 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
+ "zcash_encoding 0.4.0",
  "zcash_note_encryption",
- "zcash_protocol 0.7.1",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_spec",
- "zcash_transparent 0.6.1",
- "zip32",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
@@ -12185,27 +12179,27 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.1"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
-dependencies = [
- "core2",
- "document-features",
- "hex",
- "incrementalmerkletree",
- "incrementalmerkletree-testing",
- "memuse",
- "proptest",
- "zcash_encoding 0.3.0 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
-]
-
-[[package]]
-name = "zcash_protocol"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b1a337bbc9a7d55ae35d31189f03507dbc7934e9a4bee5c1d5c47464860e48"
 dependencies = [
  "core2",
  "hex",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.9.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "incrementalmerkletree",
+ "incrementalmerkletree-testing",
+ "memuse",
+ "proptest",
+ "zcash_encoding 0.4.0",
 ]
 
 [[package]]
@@ -12252,33 +12246,8 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.9.0",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0",
  "zcash_protocol 0.6.2",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.6.1"
-source = "git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b#e6a9772c71c928c7b507c6b18e2ae0adea5c325b"
-dependencies = [
- "bip32",
- "blake2b_simd",
- "bs58 0.5.1",
- "core2",
- "document-features",
- "getset",
- "hex",
- "proptest",
- "ripemd 0.1.3",
- "secp256k1 0.29.1",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.10.1 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_encoding 0.3.0 (git+https://github.com/Near-One/librustzcash?rev=e6a9772c71c928c7b507c6b18e2ae0adea5c325b)",
- "zcash_protocol 0.7.1",
- "zcash_script",
  "zcash_spec",
  "zip32",
 ]
@@ -12299,9 +12268,34 @@ dependencies = [
  "ripemd 0.1.3",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0",
  "zcash_protocol 0.7.2",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.8.0"
+source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
+dependencies = [
+ "bip32",
+ "bs58 0.5.1",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty",
+ "proptest",
+ "ripemd 0.1.3",
+ "secp256k1 0.29.1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.12.0",
+ "zcash_encoding 0.4.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -12324,7 +12318,7 @@ dependencies = [
  "chrono",
  "dirs",
  "ed25519-zebra",
- "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash 0.2.2",
  "futures",
  "group",
  "halo2_proofs",
@@ -12356,7 +12350,7 @@ dependencies = [
  "uint 0.10.0",
  "x25519-dalek",
  "zcash_address 0.9.0",
- "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0",
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.24.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -2716,6 +2717,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,13 +2994,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
+checksum = "775765289f7c6336c18d3d66127527820dd45ffd9eb3b6b8ee4708590e6c20f5"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "ed25519 2.2.3",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
  "pkcs8",
  "rand_core 0.6.4",
  "serde",
@@ -3120,12 +3132,12 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
  "document-features",
 ]
 
@@ -3742,26 +3754,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "halo2_gadgets"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
-dependencies = [
- "arrayvec",
- "bitvec",
- "ff",
- "group",
- "halo2_poseidon",
- "halo2_proofs",
- "lazy_static",
- "pasta_curves",
- "rand 0.8.5",
- "sinsemilla",
- "subtle",
- "uint 0.9.5",
 ]
 
 [[package]]
@@ -5709,7 +5701,7 @@ dependencies = [
  "near-sdk",
  "near-token",
  "omni-types",
- "orchard 0.14.0",
+ "orchard 0.14.0 (git+https://github.com/Near-One/orchard?rev=dc5a778e31166658085d13580e541364d56a6547)",
  "pczt",
  "rand 0.8.5",
  "ripemd 0.1.3",
@@ -5724,11 +5716,11 @@ dependencies = [
  "utxo-bridge-client",
  "utxo-utils",
  "wormhole-bridge-client",
- "zcash_address 0.12.0",
+ "zcash_address 0.12.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "zcash_keys",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
- "zcash_transparent 0.8.0",
+ "zcash_primitives 0.28.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_transparent 0.8.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
@@ -5854,19 +5846,19 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "corez",
  "ff",
  "fpe",
  "getset",
  "group",
- "halo2_gadgets 0.3.1",
+ "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -5876,6 +5868,7 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -5900,7 +5893,7 @@ dependencies = [
  "fpe",
  "getset",
  "group",
- "halo2_gadgets 0.5.0",
+ "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -6064,20 +6057,20 @@ dependencies = [
  "getset",
  "jubjub",
  "nonempty",
- "orchard 0.14.0",
+ "orchard 0.14.0 (git+https://github.com/Near-One/orchard?rev=dc5a778e31166658085d13580e541364d56a6547)",
  "pasta_curves",
  "postcard",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secp256k1 0.29.1",
  "serde",
  "serde_with",
  "zcash_note_encryption",
- "zcash_primitives 0.28.0",
- "zcash_protocol 0.9.0",
+ "zcash_primitives 0.28.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "zcash_script",
- "zcash_transparent 0.8.0",
+ "zcash_transparent 0.8.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
@@ -7080,39 +7073,6 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
-dependencies = [
- "aes",
- "bellman",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "bls12_381",
- "core2",
- "document-features",
- "ff",
- "fpe",
- "getset",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "lazy_static",
- "memuse",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "subtle",
- "tracing",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "sapling-crypto"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
@@ -7161,7 +7121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
 ]
@@ -7186,6 +7146,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -7195,6 +7156,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11128,13 +11101,13 @@ dependencies = [
  "k256",
  "near-sdk",
  "omni-types",
- "orchard 0.14.0",
+ "orchard 0.14.0 (git+https://github.com/Near-One/orchard?rev=dc5a778e31166658085d13580e541364d56a6547)",
  "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_with",
- "zcash_address 0.12.0",
- "zcash_protocol 0.9.0",
+ "zcash_address 0.12.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
@@ -11984,20 +11957,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c984ae01367a4a3d20e9d34ae4e4cc0dca004b22d9a10a51eec43f43934612e"
-dependencies = [
- "bech32",
- "bs58 0.5.1",
- "core2",
- "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.6.2",
-]
-
-[[package]]
-name = "zcash_address"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
@@ -12013,14 +11972,28 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+dependencies = [
+ "bech32",
+ "bs58 0.5.1",
+ "corez",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.12.0"
 source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "bech32",
  "bs58 0.5.1",
  "corez",
  "f4jumble 0.1.1 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
- "zcash_encoding 0.4.0",
- "zcash_protocol 0.9.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
@@ -12030,6 +12003,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
  "core2",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+dependencies = [
+ "corez",
+ "hex",
  "nonempty",
 ]
 
@@ -12095,44 +12079,33 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.24.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76362b79e432bde2f22b3defcb6919d4fb50446985997169da3cc3ae4035a6d9"
+checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
 dependencies = [
- "bip32",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58 0.5.1",
- "core2",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.2.2",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
- "fpe",
- "getset",
- "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.11.0",
- "rand 0.8.5",
+ "orchard 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.6.4",
  "redjubjub",
- "ripemd 0.1.3",
- "sapling-crypto 0.5.0",
+ "sapling-crypto",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address 0.9.0",
- "zcash_encoding 0.3.0",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.6.2",
- "zcash_spec",
- "zcash_transparent 0.4.0",
- "zip32",
+ "zcash_protocol 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_transparent 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -12144,37 +12117,25 @@ dependencies = [
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
- "equihash 0.3.0",
+ "equihash 0.3.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "ff",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.14.0",
+ "orchard 0.14.0 (git+https://github.com/Near-One/orchard?rev=dc5a778e31166658085d13580e541364d56a6547)",
  "proptest",
  "rand_core 0.6.4",
  "redjubjub",
- "sapling-crypto 0.7.0",
+ "sapling-crypto",
  "secp256k1 0.29.1",
  "sha2 0.10.9",
- "zcash_encoding 0.4.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "zcash_note_encryption",
- "zcash_protocol 0.9.0",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "zcash_script",
- "zcash_transparent 0.8.0",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc76dd1f77be473e5829dbd34890bcd36d08b1e8dde2da0aea355c812a8f28"
-dependencies = [
- "core2",
- "document-features",
- "hex",
- "memuse",
+ "zcash_transparent 0.8.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
@@ -12190,6 +12151,19 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "memuse",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.9.0"
 source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "corez",
@@ -12199,14 +12173,14 @@ dependencies = [
  "incrementalmerkletree-testing",
  "memuse",
  "proptest",
- "zcash_encoding 0.4.0",
+ "zcash_encoding 0.4.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
 ]
 
 [[package]]
 name = "zcash_script"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags",
@@ -12226,30 +12200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
 dependencies = [
  "blake2b_simd",
-]
-
-[[package]]
-name = "zcash_transparent"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7c162a8aa6f708e842503ed5157032465dadfb1d7f63adf9db2d45213a0b11"
-dependencies = [
- "bip32",
- "blake2b_simd",
- "bs58 0.5.1",
- "core2",
- "document-features",
- "getset",
- "hex",
- "ripemd 0.1.3",
- "secp256k1 0.29.1",
- "sha2 0.10.9",
- "subtle",
- "zcash_address 0.9.0",
- "zcash_encoding 0.3.0",
- "zcash_protocol 0.6.2",
- "zcash_spec",
- "zip32",
 ]
 
 [[package]]
@@ -12279,6 +12229,31 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+dependencies = [
+ "bip32",
+ "bs58 0.5.1",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty",
+ "ripemd 0.1.3",
+ "secp256k1 0.29.1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.8.0"
 source = "git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01#8df665a5050004dc48177630e1630901ffce2d01"
 dependencies = [
  "bip32",
@@ -12293,9 +12268,9 @@ dependencies = [
  "secp256k1 0.29.1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.12.0",
- "zcash_encoding 0.4.0",
- "zcash_protocol 0.9.0",
+ "zcash_address 0.12.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_encoding 0.4.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
+ "zcash_protocol 0.9.0 (git+https://github.com/Near-One/librustzcash?rev=8df665a5050004dc48177630e1630901ffce2d01)",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -12303,9 +12278,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "2.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a86ec712da2f25d3edc7e5cf0b1d15ef41ab35305e253f0f7cd9cecc0f1939"
+checksum = "db447036d6c325d9b303b7583cfa1c96f09d3bd3e6eca452dfc48ee2e1ed0e14"
 dependencies = [
  "bech32",
  "bitflags",
@@ -12313,12 +12288,14 @@ dependencies = [
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
+ "bounded-vec",
  "bs58 0.5.1",
  "byteorder",
  "chrono",
+ "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash 0.2.2",
+ "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -12329,14 +12306,15 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.11.0",
+ "orchard 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.12.2",
  "rand_core 0.6.4",
  "rayon",
  "reddsa",
  "redjubjub",
  "ripemd 0.1.3",
- "sapling-crypto 0.5.0",
+ "sapling-crypto",
+ "schemars 1.2.1",
  "secp256k1 0.29.1",
  "serde",
  "serde-big-array",
@@ -12344,18 +12322,20 @@ dependencies = [
  "sha2 0.10.9",
  "sinsemilla",
  "static_assertions",
+ "strum 0.27.2",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.9.0",
- "zcash_encoding 0.3.0",
+ "zcash_address 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.24.1",
- "zcash_protocol 0.6.2",
- "zcash_transparent 0.4.0",
+ "zcash_primitives 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_script",
+ "zcash_transparent 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "bridge-cli"
-version = "0.3.61"
+version = "0.3.62"
 dependencies = [
  "alloy",
  "clap",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "near-bridge-client"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "base64 0.21.7",
  "bitcoin",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy",
  "bip0039",
@@ -11075,7 +11075,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utxo-bridge-client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,12 @@ crypto-shared = { git = "https://github.com/near-one/mpc", package = "crypto-sha
 near-mpc-contract-interface = "0.0.1"
 openssl-sys = { version = "*", features = ["vendored"] }
 light-client = { path = "bridge-sdk/light-client" }
-zcash_primitives = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
-zcash_transparent = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b", features = ["transparent-inputs"] }
-zcash_protocol = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b" }
-pczt = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b", features = ["std", "signer", "io-finalizer", "prover", "signer", "tx-extractor", "spend-finalizer", "zcp-builder"] }
-zcash_address = { git = "https://github.com/Near-One/librustzcash", rev = "e6a9772c71c928c7b507c6b18e2ae0adea5c325b" }
-orchard = { git = "https://github.com/Near-One/orchard", rev = "a43977f07e6fdadff214bb081a481756a28b41fc", default-features = false }
+zcash_primitives = { git = "https://github.com/Near-One/librustzcash", rev = "8df665a5050004dc48177630e1630901ffce2d01", default-features = false, features = ["circuits", "test-dependencies", "transparent-inputs"] }
+zcash_transparent = { git = "https://github.com/Near-One/librustzcash", rev = "8df665a5050004dc48177630e1630901ffce2d01", features = ["transparent-inputs"] }
+zcash_protocol = { git = "https://github.com/Near-One/librustzcash", rev = "8df665a5050004dc48177630e1630901ffce2d01" }
+pczt = { git = "https://github.com/Near-One/librustzcash", rev = "8df665a5050004dc48177630e1630901ffce2d01", features = ["std", "signer", "io-finalizer", "prover", "signer", "tx-extractor", "spend-finalizer", "zcp-builder"] }
+zcash_address = { git = "https://github.com/Near-One/librustzcash", rev = "8df665a5050004dc48177630e1630901ffce2d01" }
+orchard = { git = "https://github.com/Near-One/orchard", rev = "dc5a778e31166658085d13580e541364d56a6547", default-features = false }
 bip0039 = "0.12.0"
 zcash_keys = "0.12.0"
 ripemd = "0.1.3"

--- a/bridge-cli/Cargo.toml
+++ b/bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge-cli"
-version = "0.3.61"
+version = "0.3.62"
 edition = "2021"
 repository = "https://github.com/Near-One/bridge-sdk-rs"
 rust-version = "1.88.0"

--- a/bridge-cli/src/omni_connector_command.rs
+++ b/bridge-cli/src/omni_connector_command.rs
@@ -840,6 +840,11 @@ pub enum OmniConnectorSubCommand {
             default_value = "0"
         )]
         fee: u128,
+        #[clap(
+            long,
+            help = "Derive the deposit address via the UTXO connector contract view method instead of the bridge indexer service"
+        )]
+        from_contract: bool,
         #[command(flatten)]
         config_cli: CliConfig,
     },
@@ -1811,11 +1816,18 @@ pub async fn match_subcommand(cmd: OmniConnectorSubCommand, network: Network) {
             recipient_id,
             refund_address,
             fee,
+            from_contract,
             config_cli,
         } => {
             let omni_connector = omni_connector(network, config_cli);
             let btc_address = omni_connector
-                .get_btc_address(chain.into(), &recipient_id, refund_address, fee)
+                .get_btc_address(
+                    chain.into(),
+                    &recipient_id,
+                    refund_address,
+                    fee,
+                    from_contract,
+                )
                 .await
                 .unwrap();
 

--- a/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/near-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-bridge-client"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 
 [dependencies]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -172,15 +172,17 @@ pub struct TxInclusionProof {
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct FinBtcTransferArgs {
     pub deposit_msg: DepositMsg,
-    pub tx_bytes: Vec<u8>,
+    // The contract's `verify_deposit_v2` expects `tx_bytes` as a base64 string
+    // (`Base64VecU8`), not a JSON array of bytes.
+    pub tx_bytes: Base64VecU8,
     pub vout: usize,
-    pub proof: TxInclusionProof
+    pub proof: TxInclusionProof,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BtcVerifyWithdrawArgs {
     pub tx_id: String,
-    pub proof: TxInclusionProof
+    pub proof: TxInclusionProof,
 }
 
 #[serde_as]
@@ -188,7 +190,9 @@ pub struct BtcVerifyWithdrawArgs {
 pub struct BtcRequestRefundArgs {
     pub deposit_msg: DepositMsg,
     pub refund_address: String,
-    pub tx_bytes: Vec<u8>,
+    // The contract's `request_refund` expects `tx_bytes` as a base64 string
+    // (`Base64VecU8`), not a JSON array of bytes.
+    pub tx_bytes: Base64VecU8,
     pub vout: usize,
     pub proof: TxInclusionProof,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -199,7 +203,7 @@ pub struct BtcRequestRefundArgs {
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct BtcVerifyRefundFinalizeArgs {
     pub tx_id: String,
-    pub proof: TxInclusionProof
+    pub proof: TxInclusionProof,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -955,7 +955,7 @@ impl NearBridgeClient {
 
         tracing::info!(
             deposit_address = parsed.address,
-            deposit_msg = serde_json::to_string(deposit_msg).unwrap_or_default(),
+            deposit_msg = %serde_json::to_value(deposit_msg).unwrap_or_default(),
             "Fetched user deposit address"
         );
 

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -874,37 +874,50 @@ impl NearBridgeClient {
         Ok(tx_hash)
     }
 
+    /// When `from_contract` is `true`, the deposit address is derived by calling
+    /// the `get_user_deposit_address` view method on the UTXO connector contract
+    /// directly. Otherwise it is fetched from the bridge indexer service.
     pub async fn get_btc_address(
         &self,
         chain: ChainKind,
         recipient_id: &OmniAddress,
         refund_address: Option<String>,
         fee: u128,
+        from_contract: bool,
     ) -> Result<String> {
         let deposit_msg =
             self.get_deposit_msg_for_omni_bridge(recipient_id, refund_address, fee)?;
-        self.get_btc_address_from_deposit_msg(chain, &deposit_msg)
+        self.get_btc_address_from_deposit_msg(chain, &deposit_msg, from_contract)
             .await
     }
 
     /// Fetch the BTC deposit address for a `DepositMsg` that mints nBTC directly
     /// to a NEAR account (without the Omni Bridge wrapper).
+    ///
+    /// See [`Self::get_btc_address`] for the meaning of `from_contract`.
     pub async fn get_btc_address_for_near_account(
         &self,
         chain: ChainKind,
         recipient_id: AccountId,
         refund_address: Option<String>,
+        from_contract: bool,
     ) -> Result<String> {
         let deposit_msg = self.get_deposit_msg_for_near_account(recipient_id, refund_address);
-        self.get_btc_address_from_deposit_msg(chain, &deposit_msg)
+        self.get_btc_address_from_deposit_msg(chain, &deposit_msg, from_contract)
             .await
     }
 
+    /// See [`Self::get_btc_address`] for the meaning of `from_contract`.
     pub async fn get_btc_address_from_deposit_msg(
         &self,
         chain: ChainKind,
         deposit_msg: &DepositMsg,
+        from_contract: bool,
     ) -> Result<String> {
+        if from_contract {
+            return self.get_btc_address_from_contract(chain, deposit_msg).await;
+        }
+
         let api_url = self
             .bridge_indexer_api_url()?
             .join("api/v3/utxo/get_user_deposit_address")
@@ -956,10 +969,42 @@ impl NearBridgeClient {
         tracing::info!(
             deposit_address = parsed.address,
             deposit_msg = %serde_json::to_value(deposit_msg).unwrap_or_default(),
-            "Fetched user deposit address"
+            "Fetched user deposit address from indexer"
         );
 
         Ok(parsed.address)
+    }
+
+    /// Derive the user deposit address by calling the `get_user_deposit_address`
+    /// view method on the UTXO connector contract directly, bypassing the bridge
+    /// indexer service.
+    async fn get_btc_address_from_contract(
+        &self,
+        chain: ChainKind,
+        deposit_msg: &DepositMsg,
+    ) -> Result<String> {
+        let endpoint = self.endpoint()?;
+        let btc_connector = self.utxo_chain_connector(chain)?;
+
+        let response = near_rpc_client::view(
+            endpoint,
+            ViewRequest {
+                contract_account_id: btc_connector,
+                method_name: "get_user_deposit_address".to_string(),
+                args: serde_json::json!({ "deposit_msg": deposit_msg }),
+            },
+        )
+        .await?;
+
+        let address: String = serde_json::from_slice(&response)?;
+
+        tracing::info!(
+            deposit_address = address,
+            deposit_msg = %serde_json::to_value(deposit_msg).unwrap_or_default(),
+            "Fetched user deposit address from contract"
+        );
+
+        Ok(address)
     }
 
     /// Look up the `DepositMsg` that was stored by the bridge indexer when a
@@ -1523,7 +1568,7 @@ mod tests {
 
         let client = test_client(Some(server.uri().parse().unwrap()));
         let result = client
-            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0, false)
             .await
             .expect("get_btc_address should succeed");
 
@@ -1548,7 +1593,7 @@ mod tests {
 
         let client = test_client(Some(server.uri().parse().unwrap()));
         client
-            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0, false)
             .await
             .expect("get_btc_address should succeed");
     }
@@ -1571,7 +1616,7 @@ mod tests {
 
         let client = test_client(Some(server.uri().parse().unwrap()));
         client
-            .get_btc_address(ChainKind::Zcash, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Zcash, &near_recipient(), None, 0, false)
             .await
             .expect("get_btc_address should succeed");
     }
@@ -1593,7 +1638,7 @@ mod tests {
 
         let client = test_client(Some(server.uri().parse().unwrap()));
         client
-            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 4242)
+            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 4242, false)
             .await
             .expect("get_btc_address should succeed");
 
@@ -1616,7 +1661,7 @@ mod tests {
         // No mock mounted: a successful HTTP call would fail. We expect early validation.
         let client = test_client(Some(server.uri().parse().unwrap()));
         let err = client
-            .get_btc_address(ChainKind::Eth, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Eth, &near_recipient(), None, 0, false)
             .await
             .expect_err("Eth is not a UTXO chain");
 
@@ -1630,7 +1675,7 @@ mod tests {
     async fn get_btc_address_missing_api_url_returns_config_error() {
         let client = test_client(None);
         let err = client
-            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0, false)
             .await
             .expect_err("missing api url should fail");
 
@@ -1651,7 +1696,7 @@ mod tests {
 
         let client = test_client(Some(server.uri().parse().unwrap()));
         let err = client
-            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0)
+            .get_btc_address(ChainKind::Btc, &near_recipient(), None, 0, false)
             .await
             .expect_err("500 status should fail");
 

--- a/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
+++ b/bridge-sdk/bridge-clients/near-bridge-client/src/btc.rs
@@ -953,6 +953,12 @@ impl NearBridgeClient {
         .await?;
         let parsed: DepositAddressResponse = serde_json::from_str(&body)?;
 
+        tracing::info!(
+            deposit_address = parsed.address,
+            deposit_msg = serde_json::to_string(deposit_msg).unwrap_or_default(),
+            "Fetched user deposit address"
+        );
+
         Ok(parsed.address)
     }
 

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
@@ -19,7 +19,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
-zebra-chain = "2.0.0"
+zebra-chain = "10.0.0"
 
 [lib]
 path = "src/utxo_bridge_client.rs"

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utxo-bridge-client"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
+++ b/bridge-sdk/bridge-clients/utxo-bridge-client/src/utxo_bridge_client.rs
@@ -220,8 +220,7 @@ impl<T: UTXOChain> UTXOBridgeClient<T> {
             .collect();
 
         let coinbase_tx_id = transactions[0].to_string();
-        let coinbase_merkle_proof =
-            merkle_tools::merkle_proof_calculator(transactions, 0);
+        let coinbase_merkle_proof = merkle_tools::merkle_proof_calculator(transactions, 0);
         let coinbase_merkle_proof_str = coinbase_merkle_proof
             .iter()
             .map(std::string::ToString::to_string)

--- a/bridge-sdk/connectors/omni-connector/Cargo.toml
+++ b/bridge-sdk/connectors/omni-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-connector"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.88.0"
 

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -911,44 +911,54 @@ impl OmniConnector {
             .await
     }
 
+    /// When `from_contract` is `true`, the deposit address is derived by calling
+    /// the `get_user_deposit_address` view method on the UTXO connector contract
+    /// directly. Otherwise it is fetched from the bridge indexer service.
     pub async fn get_btc_address(
         &self,
         chain: ChainKind,
         recipient_id: &OmniAddress,
         refund_address: Option<String>,
         fee: u128,
+        from_contract: bool,
     ) -> Result<String> {
         let near_bridge_client = self.near_bridge_client()?;
         near_bridge_client
-            .get_btc_address(chain, recipient_id, refund_address, fee)
+            .get_btc_address(chain, recipient_id, refund_address, fee, from_contract)
             .await
     }
 
     /// Fetch a BTC deposit address that mints nBTC directly to a NEAR account,
     /// bypassing the Omni Bridge wrapper.
+    ///
+    /// See [`Self::get_btc_address`] for the meaning of `from_contract`.
     pub async fn get_btc_address_for_near_account(
         &self,
         chain: ChainKind,
         recipient_id: AccountId,
         refund_address: Option<String>,
+        from_contract: bool,
     ) -> Result<String> {
         let near_bridge_client = self.near_bridge_client()?;
         near_bridge_client
-            .get_btc_address_for_near_account(chain, recipient_id, refund_address)
+            .get_btc_address_for_near_account(chain, recipient_id, refund_address, from_contract)
             .await
     }
 
     /// Fetch the BTC deposit address for an arbitrary `DepositMsg` (including
     /// custom `safe_deposit.msg`). Use this when neither `get_btc_address` nor
     /// `get_btc_address_for_near_account` covers the exact `DepositMsg` shape.
+    ///
+    /// See [`Self::get_btc_address`] for the meaning of `from_contract`.
     pub async fn get_btc_address_from_deposit_msg(
         &self,
         chain: ChainKind,
         deposit_msg: &DepositMsg,
+        from_contract: bool,
     ) -> Result<String> {
         let near_bridge_client = self.near_bridge_client()?;
         near_bridge_client
-            .get_btc_address_from_deposit_msg(chain, deposit_msg)
+            .get_btc_address_from_deposit_msg(chain, deposit_msg, from_contract)
             .await
     }
 
@@ -976,7 +986,7 @@ impl OmniConnector {
                 refund_address,
                 fee,
             } => {
-                self.get_btc_address(chain, recipient_id, refund_address.clone(), *fee)
+                self.get_btc_address(chain, recipient_id, refund_address.clone(), *fee, false)
                     .await?
             }
             BtcDepositArgs::NearDirectDepositArgs {
@@ -987,11 +997,13 @@ impl OmniConnector {
                     chain,
                     recipient_id.clone(),
                     refund_address.clone(),
+                    false,
                 )
                 .await?
             }
             BtcDepositArgs::DepositMsg { msg } => {
-                self.get_btc_address_from_deposit_msg(chain, msg).await?
+                self.get_btc_address_from_deposit_msg(chain, msg, false)
+                    .await?
             }
         };
 
@@ -2086,7 +2098,7 @@ impl OmniConnector {
         let utxo_bridge_client = self.utxo_bridge_client(chain_kind)?;
 
         let deposit_address = near_bridge_client
-            .get_btc_address(chain_kind, &recipient, refund_address, fee)
+            .get_btc_address(chain_kind, &recipient, refund_address, fee, false)
             .await?;
         let tx_data = utxo_bridge_client
             .get_bridge_transaction_data(&tx_hash, &deposit_address)

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -32,7 +32,7 @@ use evm_bridge_client::{EvmBridgeClient, InitTransferFilter};
 use near_bridge_client::btc::{
     BtcConfirmationContext, BtcRequestRefundArgs, BtcVerifyRefundFinalizeArgs,
     BtcVerifyWithdrawArgs, ChainSpecificData, DepositMsg, FinBtcTransferArgs,
-    NearToBtcTransferInfo, TokenReceiverMessage, VUTXO, TxInclusionProof
+    NearToBtcTransferInfo, TokenReceiverMessage, TxInclusionProof, VUTXO,
 };
 use near_bridge_client::{Decimals, NearBridgeClient, TransactionOptions};
 use solana_bridge_client::{
@@ -647,7 +647,7 @@ impl OmniConnector {
 
         Ok(FinBtcTransferArgs {
             deposit_msg,
-            tx_bytes: proof_data.tx_bytes,
+            tx_bytes: near_sdk::json_types::Base64VecU8(proof_data.tx_bytes),
             vout,
             proof: TxInclusionProof {
                 tx_block_blockhash: proof_data.tx_block_blockhash,
@@ -655,7 +655,7 @@ impl OmniConnector {
                 merkle_proof: proof_data.merkle_proof,
                 coinbase_tx_id: proof_data.coinbase_tx_id,
                 coinbase_merkle_proof: proof_data.coinbase_merkle_proof,
-            }
+            },
         })
     }
 
@@ -708,7 +708,7 @@ impl OmniConnector {
                 merkle_proof: proof_data.merkle_proof,
                 coinbase_tx_id: proof_data.coinbase_tx_id,
                 coinbase_merkle_proof: proof_data.coinbase_merkle_proof,
-            }
+            },
         };
 
         near_bridge_client
@@ -760,7 +760,7 @@ impl OmniConnector {
                 merkle_proof: proof_data.merkle_proof,
                 coinbase_tx_id: proof_data.coinbase_tx_id,
                 coinbase_merkle_proof: proof_data.coinbase_merkle_proof,
-            }
+            },
         };
 
         near_bridge_client
@@ -831,7 +831,7 @@ impl OmniConnector {
         Ok(BtcRequestRefundArgs {
             deposit_msg,
             refund_address,
-            tx_bytes: proof_data.tx_bytes,
+            tx_bytes: near_sdk::json_types::Base64VecU8(proof_data.tx_bytes),
             vout,
             proof: TxInclusionProof {
                 tx_block_blockhash: proof_data.tx_block_blockhash,
@@ -903,7 +903,7 @@ impl OmniConnector {
                 merkle_proof: proof_data.merkle_proof,
                 coinbase_tx_id: proof_data.coinbase_tx_id,
                 coinbase_merkle_proof: proof_data.coinbase_merkle_proof,
-            }
+            },
         };
 
         near_bridge_client

--- a/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
+++ b/bridge-sdk/connectors/omni-connector/src/omni_connector.rs
@@ -1569,6 +1569,7 @@ impl OmniConnector {
             Some(rate) => rate,
             None => utxo_bridge_client.get_fee_rate().await?,
         };
+
         let gas_fee = get_gas_fee(
             chain,
             u64::try_from(btc_pending_info.vutxos.len()).map_err(|e| {

--- a/bridge-sdk/connectors/omni-connector/src/zcash.rs
+++ b/bridge-sdk/connectors/omni-connector/src/zcash.rs
@@ -99,7 +99,7 @@ impl OmniConnector {
             );
 
             builder
-                .add_transparent_input(transparent_pubkey, utxo, coin)
+                .add_transparent_p2pkh_input(transparent_pubkey, utxo, coin)
                 .map_err(|err| {
                     BridgeSdkError::ZCashOrchardBundleError(format!(
                         "Failed to add transparent input for UTXO: {err}"
@@ -268,7 +268,7 @@ impl OmniConnector {
             .add_orchard_output::<zip317::FeeRule>(
                 Some(orchard::keys::OutgoingViewingKey::from([0u8; 32])),
                 recipient,
-                amount,
+                zcash_protocol::value::Zatoshis::const_from_u64(amount),
                 memo_bytes,
             )
             .map_err(|err| {


### PR DESCRIPTION
- Bump Zcash deps: librustzcash & orchard revs, zebra-chain 2.0 → 10.0; adapt to new API
  (`add_transparent_p2pkh_input`, `Zatoshis` for orchard output amount)
- Wrap `tx_bytes` in `Base64VecU8` when building fin-transfer / refund args
- Add `from_contract` flag to `get_btc_address*` (CLI `--from-contract`) to derive the
  deposit address via the connector contract instead of the indexer — needed for e2e tests
- Log the resolved deposit address together with its `DepositMsg`